### PR TITLE
Refactor: Button

### DIFF
--- a/src/components/ui/button/button.module.css
+++ b/src/components/ui/button/button.module.css
@@ -5,12 +5,14 @@
 
   position: relative;
   z-index: 1;
-  display: flex;
+  display: grid;
   box-sizing: border-box;
   align-items: center;
   border: 0;
   background-color: transparent;
   cursor: pointer;
+  grid-template-columns: max-content max-content;
+  grid-template-rows: 100%;
 
   &::before {
     position: absolute;
@@ -49,10 +51,6 @@
   }
 }
 
-.addon {
-  justify-content: space-between;
-}
-
 .l.button,
 .l.button.addon {
   @mixin textLargeButton;
@@ -66,7 +64,7 @@
   background-color: var(--light-green);
 }
 
-.left.button {
+.left.button.addon {
   padding-left: 0;
 }
 

--- a/src/components/ui/button/button.module.css
+++ b/src/components/ui/button/button.module.css
@@ -1,18 +1,18 @@
 .button {
+  @mixin text;
+
   position: relative;
   z-index: 1;
   display: flex;
   box-sizing: border-box;
   align-items: center;
   border: 0;
-  background-color: var(--beige);
+  background-color: transparent;
   cursor: pointer;
   font-size: 16px;
   line-height: 14px;
   outline: 0;
   text-transform: uppercase;
-
-  @mixin text;
 
   &::before {
     position: absolute;
@@ -57,26 +57,22 @@
 
 .l.button,
 .l.button.addon {
+  @mixin textSmall;
+
   align-items: center;
   justify-content: space-between;
   padding: 16px 16px 18px 16px;
-
-  @mixin textSmall;
 }
 
 .secondary {
   background-color: var(--light-green);
 }
 
-.transparent {
-  background-color: transparent;
-}
-
-.leftAddon.button {
+.left.button {
   padding-left: 0;
 }
 
-.leftAddon.button.l {
+.left.button.l {
   padding-left: 16px;
 }
 

--- a/src/components/ui/button/button.module.css
+++ b/src/components/ui/button/button.module.css
@@ -1,5 +1,7 @@
 .button {
   @mixin text;
+  @mixin textButton;
+  @mixin textSmallButton;
 
   position: relative;
   z-index: 1;
@@ -9,10 +11,6 @@
   border: 0;
   background-color: transparent;
   cursor: pointer;
-  font-size: 16px;
-  line-height: 14px;
-  outline: 0;
-  text-transform: uppercase;
 
   &::before {
     position: absolute;
@@ -57,7 +55,7 @@
 
 .l.button,
 .l.button.addon {
-  @mixin textSmall;
+  @mixin textLargeButton;
 
   align-items: center;
   justify-content: space-between;

--- a/src/components/ui/button/button.stories.tsx
+++ b/src/components/ui/button/button.stories.tsx
@@ -73,7 +73,6 @@ Download.args = {
   size: 's',
   iconPlace: 'right',
   icon: 'arrow-down',
-  view: 'transparent',
   label: 'Скачать',
   border: 'none',
 };
@@ -104,7 +103,6 @@ export const Send = Template.bind({});
 Send.args = {
   width: '240px',
   size: 'l',
-  view: 'transparent',
   iconPlace: 'right',
   icon: 'arrow-right',
   label: 'Отправить',
@@ -115,7 +113,6 @@ export const FormButtonDisabled = Template.bind({});
 FormButtonDisabled.args = {
   width: '360px',
   size: 'l',
-  view: 'transparent',
   iconPlace: 'right',
   icon: 'ok',
   label: 'Отправлено',
@@ -126,11 +123,9 @@ FormButtonDisabled.args = {
 export const BackButton_Link = Template.bind({});
 BackButton_Link.args = {
   size: 's',
-  view: 'transparent',
   iconPlace: 'right',
   icon: 'arrow-left',
   label: 'Бибилиотека',
   border: 'bottomRight',
-  disabled: true,
   isLink: true,
 };

--- a/src/components/ui/button/button.stories.tsx
+++ b/src/components/ui/button/button.stories.tsx
@@ -129,3 +129,27 @@ BackButton_Link.args = {
   border: 'bottomRight',
   isLink: true,
 };
+
+export const Tickets = Template.bind({});
+Tickets.args = {
+  size: 's',
+  iconPlace: 'left',
+  icon: 'arrow-right',
+  label: 'Билеты',
+  border: 'bottomLeft',
+  isLink: true,
+  align: 'start',
+  gap: '9px',
+  width: '154px',
+};
+
+export const Support = Template.bind({});
+Support.args = {
+  label: 'Поддержать',
+  view: 'primary',
+  icon: 'plus',
+  iconPlace: 'left',
+  isLink: true,
+  align: 'center',
+  width: '165px',
+};

--- a/src/components/ui/button/button.tsx
+++ b/src/components/ui/button/button.tsx
@@ -57,8 +57,8 @@ export const Button: FC<IButtonProps> = (props) => {
         {buttonChildren}
       </button>
       ||
-      <Link href={href} {...restButtonProps}>
-        <a
+      <Link href={href} {...restButtonProps} >
+        <a  style={{width}}
           className={cx(classes, 'link')}>
           {buttonChildren}
         </a>

--- a/src/components/ui/button/button.tsx
+++ b/src/components/ui/button/button.tsx
@@ -16,6 +16,8 @@ interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string,
   isLink?: boolean,
   href?: string,
+  align?: 'start' | 'end' | 'center' | 'space-between',
+  gap?: string
 }
 
 const cx = cn.bind(styles);
@@ -30,14 +32,16 @@ export const Button: FC<IButtonProps> = (props) => {
     iconPlace,
     label,
     width,
+    align = 'space-between',
     border = 'none',
     disabled = false,
     className = '',
+    gap = '0',
     ...restButtonProps
   } = props;
 
   const classes = cx('button', view, border, icon && 'addon', iconPlace, iconPlace, size, [className]);
-
+  const style = {width: width, justifyContent: align, columnGap: gap};
   const buttonChildren = (
     <React.Fragment>
       {iconPlace === 'left' && icon && <Icon glyph={icon}/>}
@@ -52,13 +56,13 @@ export const Button: FC<IButtonProps> = (props) => {
         className={classes}
         type='button'
         disabled={disabled}
-        style={{width}}
+        style={style}
         {...restButtonProps}>
         {buttonChildren}
       </button>
       ||
       <Link href={href} {...restButtonProps} >
-        <a  style={{width}}
+        <a  style={style}
           className={cx(classes, 'link')}>
           {buttonChildren}
         </a>

--- a/src/components/ui/button/button.tsx
+++ b/src/components/ui/button/button.tsx
@@ -1,11 +1,12 @@
 import React, {FC, ButtonHTMLAttributes} from 'react';
 import Link from 'next/link';
-import cn from 'classnames';
-import styles from './button.module.css';
+import cn from 'classnames/bind';
 import {Icon, IIconProps} from '../icon';
 
+import styles from './button.module.css';
+
 interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  view?: 'primary' | 'secondary' | 'transparent',
+  view?: 'primary' | 'secondary',
   iconPlace?: 'left' | 'right',
   icon?: IIconProps['glyph'],
   size?: 's' | 'l';
@@ -16,6 +17,8 @@ interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isLink?: boolean,
   href?: string,
 }
+
+const cx = cn.bind(styles);
 
 export const Button: FC<IButtonProps> = (props) => {
   const {
@@ -32,16 +35,9 @@ export const Button: FC<IButtonProps> = (props) => {
     className = '',
     ...restButtonProps
   } = props;
-  const classes = cn(
-    styles.button,
-    styles[view],
-    styles[border],
-    icon && styles.addon,
-    iconPlace === 'left' && styles.leftAddon,
-    iconPlace === 'right' && styles.rightAddon,
-    size === 'l' && styles.l,
-    [className]
-  );
+
+  const classes = cx('button', view, border, icon && 'addon', iconPlace, iconPlace, size, [className]);
+
   const buttonChildren = (
     <React.Fragment>
       {iconPlace === 'left' && icon && <Icon glyph={icon}/>}
@@ -61,9 +57,9 @@ export const Button: FC<IButtonProps> = (props) => {
         {buttonChildren}
       </button>
       ||
-      <Link href={href}>
+      <Link href={href} {...restButtonProps}>
         <a
-          className={cn(classes, styles.link)}>
+          className={cx(classes, 'link')}>
           {buttonChildren}
         </a>
       </Link>

--- a/src/shared/styles/mixins/text.css
+++ b/src/shared/styles/mixins/text.css
@@ -26,3 +26,16 @@
   font-size: 14px;
   line-height: 17px;
 }
+
+@define-mixin textButton {
+  text-transform: uppercase;
+}
+
+@define-mixin textSmallButton {
+  font-size: 16px;
+  line-height: 14px;
+}
+
+@define-mixin textLargeButton {
+  @mixin textSmall;
+}


### PR DESCRIPTION
## Описание
Небольшой рефакторинг компонента button.

## Изменения
- Теперь нет параметра view: 'transparent', а прозрачный фон - часть vew: 'primary'
- Использовал 'classnames / bind' для формирования списка классов
- Добавил 3 общих миксина в text.css, чтобы можно было централизованно управлять текстовыми стилями кнопок. 
  - @textButton, общий для всех кнопок с единственным значением text-transform: uppercase;
  - @textSmallButton 16 / 14, так как того же стиля не было в других текстовых миксинах
  - @textLargeButton копирует @textSmall
  - Исправлена ошибка, по которой не передавался параметр фиксированной ширины **width**, когда компонент **button** является ссылкой.
  - Изменён способ форматирования внутри кнопки на **grid**
  - Новые свойства компонента:
    - **gap** - задаёт в пикселях отступ между иконкой и текстом. По-умолчанию 0. Изменяет параметр column-gap
    - **align** - задаёт способ выравнивания: возможные варианты **start, center, end, space-between**. По-умолчанию - space-between. Изменяет параметр **justify-content.**
 
Возможно такое добавление миксинов излишнее - если так, то уберу или оставлю только @textSmallButton.

## Ссылка на задачу
https://www.notion.so/front-52aae4efcc1743f58f4abf64bf7357ff?p=ffecf503cbca435cb80babe415d83bae
