### PR TITLE
Обновление eslint-plugin-react до версии 7.26.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,10 @@
 {
   "name": "lubimovka_frontend",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-<<<<<<< HEAD
-=======
   "packages": {
     "": {
-      "name": "lubimovka_frontend",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "UNLICENSED",
@@ -30,7 +27,7 @@
         "babel-loader": "8.2.2",
         "classnames": "2.3.1",
         "eslint": "7.32.0",
-        "eslint-plugin-react": "7.25.1",
+        "eslint-plugin-react": "7.26.1",
         "lint-staged": "11.1.2",
         "postcss-mixins": "8.1.0",
         "postcss-nested": "5.0.6",
@@ -9500,9 +9497,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -9515,7 +9512,9 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -9525,6 +9524,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-array-method-boxes-properly": {
@@ -9706,27 +9708,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
-      "integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
+      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
         "estraverse": "^5.2.0",
-        "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
         "object.entries": "^1.1.4",
         "object.fromentries": "^2.0.4",
+        "object.hasown": "^1.0.0",
         "object.values": "^1.1.4",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.5"
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -12649,6 +12655,14 @@
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
       "dev": true
     },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -12708,6 +12722,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-whitespace-character": {
@@ -15078,6 +15103,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.pick": {
@@ -22191,7 +22229,6 @@
       "dev": true
     }
   },
->>>>>>> 30ec87566c68b34ac3a92fbcd5c4a9b96137a68c
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.12.11",
@@ -30228,9 +30265,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -30243,7 +30280,9 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -30594,23 +30633,24 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
-      "integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
+      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
         "estraverse": "^5.2.0",
-        "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
         "object.entries": "^1.1.4",
         "object.fromentries": "^2.0.4",
+        "object.hasown": "^1.0.0",
         "object.values": "^1.1.4",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.5"
       },
       "dependencies": {
@@ -32827,6 +32867,11 @@
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
       "dev": true
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -32872,6 +32917,14 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -34863,6 +34916,16 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.2"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
       }
     },
     "object.pick": {
@@ -38031,6 +38094,14 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -38124,14 +38195,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-loader": "8.2.2",
     "classnames": "2.3.1",
     "eslint": "7.32.0",
-    "eslint-plugin-react": "7.25.1",
+    "eslint-plugin-react": "7.26.1",
     "lint-staged": "11.1.2",
     "postcss-mixins": "8.1.0",
     "postcss-nested": "5.0.6",


### PR DESCRIPTION
## Описание
Обновление eslint-plugin-react до версии 7.26.1.

До этого обновления линтер выдавал ошибку, если неявно использовать children в компоненте с аннотацией типа React.FC. С учетом того, что в типе React.FC предусмотрен опциональный children, такое поведение вводит в заблуждение. Обновление убирает эту ошибку.

После вливания этой ветки рекомендую:
1. Удалить файл кэша линтера `.eslintcache`
2. Рестартануть eslint server

В ином случае, могут быть ошибки при выполнении команды `npm run lint:js`.