### PR TITLE
Announced Play Card fix - WIP

### DIFF
--- a/src/components/ui/announced-play-card/announced-play-card.module.css
+++ b/src/components/ui/announced-play-card/announced-play-card.module.css
@@ -4,7 +4,7 @@
   flex-direction: row;
   list-style-type: none;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     width: 100%;
     padding: 32px 0;
     border-top: var(--coal) solid 1px;
@@ -12,7 +12,7 @@
 }
 
 .card:last-child {
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     border-bottom: var(--coal) solid 1px;
   }
 }
@@ -23,7 +23,7 @@
   padding-right: 31px;
   object-fit: cover;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     width: 92px;
     height: 123px;
   }
@@ -49,7 +49,7 @@
   margin: 0;
   margin-right: 44px;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     margin-right: 46px;
   }
 }
@@ -67,7 +67,7 @@
   width: 419px;
   margin-top: 4px;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     width: 382px;
     margin-top: 16px;
   }
@@ -86,7 +86,7 @@
   flex-direction: column;
   margin: 16px 0 0 30px;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     margin-left: 0;
   }
 }
@@ -104,7 +104,7 @@
   width: 359px;
   margin: 16px 0 0 30px;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     margin-left: 0;
   }
 }
@@ -117,7 +117,7 @@
   padding-top: 20px;
   margin: 0;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     padding-top: 8px;
   }
 }
@@ -125,7 +125,7 @@
 .button {
   margin-bottom: 16px;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     margin-right: 26px;
     margin-bottom: 0;
   }
@@ -138,7 +138,7 @@
 .buttonContainer {
   margin-top: 16px;
 
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     display: flex;
     width: 380px;
     flex-direction: row;
@@ -146,14 +146,14 @@
 }
 
 .buttonContainerCoverExists {
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     margin-top: 48px;
     margin-left: -123px;
   }
 }
 
 .buttonContainerNoCover {
-  @media (max-width: 576px) {
+  @media (max-width: $tablet-portrait) {
     margin-left: 0;
   }
 }

--- a/src/components/ui/announced-play-card/announced-play-card.module.css
+++ b/src/components/ui/announced-play-card/announced-play-card.module.css
@@ -1,4 +1,4 @@
-.cardEvents {
+.card {
   display: flex;
   max-width: 420px;
   flex-direction: row;
@@ -11,13 +11,13 @@
   }
 }
 
-.cardEvents:last-child {
+.card:last-child {
   @media (max-width: 576px) {
     border-bottom: var(--coal) solid 1px;
   }
 }
 
-.coverEvents {
+.cover {
   width: 120px;
   height: 161px;
   padding-right: 31px;
@@ -29,7 +29,7 @@
   }
 }
 
-.infoEvents {
+.info {
   display: flex;
   width: 269px;
   flex-direction: column;
@@ -54,7 +54,7 @@
   }
 }
 
-.timeEvents {
+.time {
   padding: 0;
   margin: 0;
 }
@@ -122,7 +122,7 @@
   }
 }
 
-.buttonEvents {
+.button {
   margin-bottom: 16px;
 
   @media (max-width: 576px) {
@@ -131,11 +131,11 @@
   }
 }
 
-.buttonEvents:last-child {
+.button:last-child {
   margin-bottom: 0;
 }
 
-.buttonEventsContainer {
+.buttonContainer {
   margin-top: 16px;
 
   @media (max-width: 576px) {
@@ -145,14 +145,14 @@
   }
 }
 
-.buttonEventsContainerCoverExists {
+.buttonContainerCoverExists {
   @media (max-width: 576px) {
     margin-top: 48px;
     margin-left: -123px;
   }
 }
 
-.buttonEventsContainerNoCover {
+.buttonContainerNoCover {
   @media (max-width: 576px) {
     margin-left: 0;
   }

--- a/src/components/ui/announced-play-card/announced-play-card.module.css
+++ b/src/components/ui/announced-play-card/announced-play-card.module.css
@@ -63,11 +63,18 @@
   @mixin headline;
   @mixin headline5;
 
+  display: block;
+  width: 419px;
   margin-top: 4px;
 
   @media (max-width: 576px) {
+    width: 382px;
     margin-top: 16px;
   }
+}
+
+.titleNoCover {
+  margin-top: 16px;
 }
 
 .credits {
@@ -88,6 +95,18 @@
   display: inline;
   padding: 0;
   margin: 0;
+}
+
+.eventDescription {
+  @mixin text;
+  @mixin textSmall;
+
+  width: 359px;
+  margin: 16px 0 0 30px;
+
+  @media (max-width: 576px) {
+    margin-left: 0;
+  }
 }
 
 .description {

--- a/src/components/ui/announced-play-card/announced-play-card.stories.tsx
+++ b/src/components/ui/announced-play-card/announced-play-card.stories.tsx
@@ -52,3 +52,14 @@ PlayCardEventsViewOneButtonNoCover.args = {
   directorArray: ['Катя Ганюшина'],
   buttonLinks: ['https://lubimovka.timepad.ru/event/1746579/'],
 };
+
+export const PlayCardEventsViewNoCredits = Template.bind({});
+PlayCardEventsViewNoCredits.args = {
+  date:'15 декабря',
+  time: '11:00',
+  title: 'Что я узнал о творчестве благодаря драматургам',
+  playwrightArray: [],
+  directorArray: [],
+  eventDescription: 'Гости расскажут о своём творческом и организационном опыте и вдохновят аудиторию преодолевать любые границы.',
+  buttonLinks: ['https://lubimovka.timepad.ru/event/1746579/'],
+};

--- a/src/components/ui/announced-play-card/announced-play-card.tsx
+++ b/src/components/ui/announced-play-card/announced-play-card.tsx
@@ -1,8 +1,10 @@
 import React, { FC } from 'react';
-import cn from 'classnames';
+import cn from 'classnames/bind';
 import { Button } from '../button';
 
 import styles from './announced-play-card.module.css';
+
+const cx = cn.bind(styles);
 
 interface IAnnouncedPlayCardProps {
   date: string;
@@ -36,21 +38,21 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
     <React.Fragment>
       {
         playwrightArray.length > 1 ?
-          (<p className={cn(styles.creditsEntry)}>
+          (<p className={cx('creditsEntry')}>
         Драматурги: {creditsArrayToString (playwrightArray)}
           </p>)
           :
-          (<p className={cn(styles.creditsEntry)}>
+          (<p className={cx('creditsEntry')}>
         Драматург: {playwrightArray}
           </p>)
       }
       {
         directorArray.length > 1 ?
-          (<p className={cn(styles.creditsEntry)}>
+          (<p className={cx('creditsEntry')}>
         Режиссёры: {creditsArrayToString (directorArray)}
           </p>)
           :
-          (<p className={cn(styles.creditsEntry)}>
+          (<p className={cx('creditsEntry')}>
           Режиссёр: {directorArray}
           </p>)
       }
@@ -59,36 +61,36 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
 
   return (
     <article
-      className={cn(styles.card)}
+      className={cx('card')}
     >
       {coverResourceUrl &&
         <div >
-          <img className={cn(styles.cover)} src={coverResourceUrl}></img>
+          <img className={cx('cover')} src={coverResourceUrl}></img>
         </div>
       }
-      <div className={cn(styles.info)}>
-        <div className={cn(styles.dateInfo)}>
-          <p className={cn(styles.date)}>{date}</p>
-          <p className={cn(styles.time)}>{time}</p>
+      <div className={cx('info')}>
+        <div className={cx('dateInfo')}>
+          <p className={cx('date')}>{date}</p>
+          <p className={cx('time')}>{time}</p>
         </div>
-        <h5 className={cn(styles.title, !coverResourceUrl && styles.titleNoCover)}>{title}</h5>
+        <h5 className={cx('title', !coverResourceUrl && 'titleNoCover')}>{title}</h5>
         { directorArray.length > 0 && playwrightArray.length > 0 &&
-        <div className={cn(styles.credits)}>
+        <div className={cx('credits')}>
           {creditsRendered}
         </div>
         }
         { eventDescription &&
-        <div className={cn(styles.eventDescription)}>
+        <div className={cx('eventDescription')}>
           {eventDescription}
         </div>
         }
-        <p className={cn(styles.description)}>читка проекта Любимовка.Ещё</p>
+        <p className={cx('description')}>читка проекта Любимовка.Ещё</p>
         {buttonLinks.length === 2 &&
-          <div className={cn(styles.buttonContainer, coverResourceUrl && styles.buttonContainerCoverExists )}>
+          <div className={cx('buttonContainer', coverResourceUrl && 'buttonContainerCoverExists' )}>
             <Button
               view='primary'
               width='154px'
-              className={styles.button}
+              className={cx('button')}
               align='start'
               gap='9px'
               size='s'
@@ -102,7 +104,7 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
             <Button
               view='primary'
               width='154px'
-              className={styles.button}
+              className={cx('button')}
               align='start'
               gap='9px'
               size='s'
@@ -116,11 +118,11 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
           </div>
         }
         {buttonLinks.length === 1 &&
-          <div className={cn(styles.buttonContainer, coverResourceUrl ? styles.buttonContainerCoverExists : styles.buttonNoCover)}>
+          <div className={cx('buttonContainer', coverResourceUrl ? 'buttonContainerCoverExists' : 'buttonNoCover')}>
             <Button
               view='primary'
               width='154px'
-              className={styles.button}
+              className={cx('button')}
               align='start'
               gap='9px'
               size='s'

--- a/src/components/ui/announced-play-card/announced-play-card.tsx
+++ b/src/components/ui/announced-play-card/announced-play-card.tsx
@@ -10,6 +10,7 @@ interface IAnnouncedPlayCardProps {
   title: string;
   playwrightArray: string [];
   directorArray: string [];
+  eventDescription?:string;
   buttonLinks: string [];
   coverResourceUrl?: string;
 }
@@ -21,9 +22,9 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
     title,
     playwrightArray,
     directorArray,
+    eventDescription,
     buttonLinks,
     coverResourceUrl,
-    ...restAnnouncedPlayCardProps
   } = props;
 
   const creditsArrayToString = (array: string []) => {
@@ -59,7 +60,6 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
   return (
     <li
       className={cn(styles.cardEvents)}
-      {...restAnnouncedPlayCardProps}
     >
       {coverResourceUrl &&
         <div className={cn(styles.coverEvents)}>
@@ -71,10 +71,17 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
           <p className={cn(styles.date)}>{date}</p>
           <p className={cn(styles.timeEvents)}>{time}</p>
         </div>
-        <h5 className={cn(styles.title)}>{title}</h5>
+        <h5 className={cn(styles.title, !coverResourceUrl && styles.titleNoCover)}>{title}</h5>
+        { directorArray.length > 0 && playwrightArray.length > 0 &&
         <div className={cn(styles.credits)}>
           {creditsRendered}
         </div>
+        }
+        { eventDescription &&
+        <div className={cn(styles.eventDescription)}>
+          {eventDescription}
+        </div>
+        }
         <p className={cn(styles.description)}>читка проекта Любимовка.Ещё</p>
         {buttonLinks.length === 2 &&
           <div className={cn(styles.buttonEventsContainer, coverResourceUrl && styles.buttonEventsContainerCoverExists )}>

--- a/src/components/ui/announced-play-card/announced-play-card.tsx
+++ b/src/components/ui/announced-play-card/announced-play-card.tsx
@@ -59,17 +59,17 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
 
   return (
     <article
-      className={cn(styles.cardEvents)}
+      className={cn(styles.card)}
     >
       {coverResourceUrl &&
-        <div className={cn(styles.coverEvents)}>
-          <img className={cn(styles.coverEvents)} src={coverResourceUrl}></img>
+        <div >
+          <img className={cn(styles.cover)} src={coverResourceUrl}></img>
         </div>
       }
-      <div className={cn(styles.infoEvents)}>
+      <div className={cn(styles.info)}>
         <div className={cn(styles.dateInfo)}>
           <p className={cn(styles.date)}>{date}</p>
-          <p className={cn(styles.timeEvents)}>{time}</p>
+          <p className={cn(styles.time)}>{time}</p>
         </div>
         <h5 className={cn(styles.title, !coverResourceUrl && styles.titleNoCover)}>{title}</h5>
         { directorArray.length > 0 && playwrightArray.length > 0 &&
@@ -84,11 +84,11 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
         }
         <p className={cn(styles.description)}>читка проекта Любимовка.Ещё</p>
         {buttonLinks.length === 2 &&
-          <div className={cn(styles.buttonEventsContainer, coverResourceUrl && styles.buttonEventsContainerCoverExists )}>
+          <div className={cn(styles.buttonContainer, coverResourceUrl && styles.buttonContainerCoverExists )}>
             <Button
               view='primary'
               width='154px'
-              className={styles.buttonEvents}
+              className={styles.button}
               align='start'
               gap='9px'
               size='s'
@@ -102,7 +102,7 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
             <Button
               view='primary'
               width='154px'
-              className={styles.buttonEvents}
+              className={styles.button}
               align='start'
               gap='9px'
               size='s'
@@ -116,11 +116,11 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
           </div>
         }
         {buttonLinks.length === 1 &&
-          <div className={cn(styles.buttonEventsContainer, coverResourceUrl ? styles.buttonEventsContainerCoverExists : styles.buttonEventsNoCover)}>
+          <div className={cn(styles.buttonContainer, coverResourceUrl ? styles.buttonContainerCoverExists : styles.buttonNoCover)}>
             <Button
               view='primary'
               width='154px'
-              className={styles.buttonEvents}
+              className={styles.button}
               align='start'
               gap='9px'
               size='s'

--- a/src/components/ui/announced-play-card/announced-play-card.tsx
+++ b/src/components/ui/announced-play-card/announced-play-card.tsx
@@ -58,7 +58,7 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
   );
 
   return (
-    <li
+    <article
       className={cn(styles.cardEvents)}
     >
       {coverResourceUrl &&
@@ -110,7 +110,7 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
               icon='arrow-right'
               label='Билеты'
               border='bottomLeft'
-              isLink={true}
+              isLink
               href={buttonLinks[1]}
             />
           </div>
@@ -128,12 +128,12 @@ export const AnnouncedPlayCard: FC<IAnnouncedPlayCardProps> = (props) => {
               icon='arrow-right'
               label='Регистрация'
               border='bottomLeft'
-              isLink={true}
+              isLink
               href={buttonLinks[0]}
             />
           </div>
         }
       </div>
-    </li>
+    </article>
   );
 };


### PR DESCRIPTION
## Описание

**Обновление логики компонента announced-play-card:** 

добавлена логика рендеринга компонента, когда приходит пустой массив с именами режиссера/ов и драматургов/а, но приходит подробное описание мероприятие (`eventDescription`). состояние в макете: 

<img width="496" alt="Снимок экрана 2021-10-14 в 03 20 32" src="https://user-images.githubusercontent.com/76454288/137230135-9766e003-39c5-463e-a1fe-926fd1d069da.png">

NB 📝 массив драматургов и режиссеров (`playwrightArray` и `directorArray`) я оставляю обязательным полем в интерфейсе, но проверяю длину массива. 

**Другие фиксы** 
1. исправлена семантика компонента `li > article `
2. упрощена запись для кнопки `isLink={true}`
3. фиксы лейаута по макету (добавлен больший отступ над названием пьесы в случае, если не приходит картинка-обложка)

UPD 16.10 
4. поправлено именование стилей 
5. исправлен брейкпойнт для мобильной версии - теперь мобильная версия отображается на tablet-portrait 

UPD 17.10 
6. исправлена запись для биндинга стилей