### PR TITLE
For Press Hero Title: Компонент с заголовком и описанием страницы О прессы

### DIFF
--- a/src/components/for-press-hero-title/assets/mock-data.json
+++ b/src/components/for-press-hero-title/assets/mock-data.json
@@ -1,5 +1,3 @@
 {
-  "title": "Для прессы",
-  "description": "Фотографии можно скачать в альбомах на странице фестиваля в Facebook.",
-  "link": "https://www.facebook.com/festival.lubimovka/photos"
+  "title": "Для прессы"
 }

--- a/src/components/for-press-hero-title/assets/mock-data.json
+++ b/src/components/for-press-hero-title/assets/mock-data.json
@@ -1,0 +1,5 @@
+{
+  "title": "Для прессы",
+  "description": "Фотографии можно скачать в альбомах на странице фестиваля в Facebook.",
+  "link": "https://www.facebook.com/festival.lubimovka/photos"
+}

--- a/src/components/for-press-hero-title/for-press-hero-title.module.css
+++ b/src/components/for-press-hero-title/for-press-hero-title.module.css
@@ -1,0 +1,36 @@
+.title {
+  @mixin headline;
+  @mixin headline1;
+
+  max-width: 450px;
+  margin-bottom: 32px;
+
+  @media (max-width: $tablet-portrait) {
+    @mixin headline4;
+
+    max-width: 367px;
+    margin-bottom: 24px;
+  }
+}
+
+.description {
+  @mixin headline;
+  @mixin headline6;
+
+  max-width: 387px;
+  margin-bottom: 30px;
+
+  @media (max-width: $tablet-portrait) {
+    @mixin headline7;
+
+    max-width: 305px;
+    margin-bottom: 24px;
+    margin-left: 62px;
+  }
+}
+
+.button {
+  @media (max-width: $tablet-portrait) {
+    margin-left: 62px;
+  }
+}

--- a/src/components/for-press-hero-title/for-press-hero-title.module.css
+++ b/src/components/for-press-hero-title/for-press-hero-title.module.css
@@ -12,25 +12,3 @@
     margin-bottom: 24px;
   }
 }
-
-.description {
-  @mixin headline;
-  @mixin headline6;
-
-  max-width: 387px;
-  margin-bottom: 30px;
-
-  @media (max-width: $tablet-portrait) {
-    @mixin headline7;
-
-    max-width: 305px;
-    margin-bottom: 24px;
-    margin-left: 62px;
-  }
-}
-
-.button {
-  @media (max-width: $tablet-portrait) {
-    margin-left: 62px;
-  }
-}

--- a/src/components/for-press-hero-title/for-press-hero-title.stories.tsx
+++ b/src/components/for-press-hero-title/for-press-hero-title.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { ForPressHeroTitle } from './for-press-hero-title';
+import mockData from './assets/mock-data.json';
+
+export default {
+  title: 'Components/ForPressHeroTitle',
+  component: ForPressHeroTitle,
+
+} as ComponentMeta<typeof ForPressHeroTitle>;
+
+const Template: ComponentStory<typeof ForPressHeroTitle> = (args) => {
+  return <ForPressHeroTitle {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  data: mockData,
+};

--- a/src/components/for-press-hero-title/for-press-hero-title.tsx
+++ b/src/components/for-press-hero-title/for-press-hero-title.tsx
@@ -1,0 +1,39 @@
+import {FC} from 'react';
+import { Button } from '../ui/button';
+import cn from 'classnames/bind';
+
+import styles from './for-press-hero-title.module.css';
+import { Url } from 'shared/types/common';
+
+const cx = cn.bind(styles);
+
+export interface IForPressHeroTitleProps {
+  data: {
+    title: string,
+    description: string,
+    link: Url,
+   },
+}
+
+export const ForPressHeroTitle: FC<IForPressHeroTitleProps> = ({ data }) => {
+
+  return (
+    <section>
+      <h1 className={cx('title')}>{data.title}</h1>
+      <p className={cx('description')}>{data.description}</p>
+      <Button
+        className={cx('button')}
+        align='start'
+        width='173px'
+        size='s'
+        view='primary'
+        iconPlace='left'
+        icon='arrow-right'
+        label='Фотоальбомы'
+        border='bottomLeft'
+        isLink
+        href={data.link}
+      />
+    </section>
+  );
+};

--- a/src/components/for-press-hero-title/for-press-hero-title.tsx
+++ b/src/components/for-press-hero-title/for-press-hero-title.tsx
@@ -1,39 +1,21 @@
 import {FC} from 'react';
-import { Button } from '../ui/button';
 import cn from 'classnames/bind';
 
 import styles from './for-press-hero-title.module.css';
-import { Url } from 'shared/types/common';
 
 const cx = cn.bind(styles);
 
 export interface IForPressHeroTitleProps {
   data: {
     title: string,
-    description: string,
-    link: Url,
    },
 }
 
 export const ForPressHeroTitle: FC<IForPressHeroTitleProps> = ({ data }) => {
 
   return (
-    <section>
-      <h1 className={cx('title')}>{data.title}</h1>
-      <p className={cx('description')}>{data.description}</p>
-      <Button
-        className={cx('button')}
-        align='start'
-        width='173px'
-        size='s'
-        view='primary'
-        iconPlace='left'
-        icon='arrow-right'
-        label='Фотоальбомы'
-        border='bottomLeft'
-        isLink
-        href={data.link}
-      />
-    </section>
+    <h1 className={cx('title')}>
+      {data.title}
+    </h1>
   );
 };

--- a/src/components/for-press-hero-title/index.tsx
+++ b/src/components/for-press-hero-title/index.tsx
@@ -1,0 +1,1 @@
+export * from './for-press-hero-title';


### PR DESCRIPTION
## Описание
Создан компонент с заголовком и описанием страницы О прессе. 
![Снимок экрана 2021-10-24 в 22 49 39](https://user-images.githubusercontent.com/76454288/138610377-adc4b945-148e-4dc6-b631-19000e049a8f.png)

![Снимок экрана 2021-10-24 в 22 49 49](https://user-images.githubusercontent.com/76454288/138610382-e19cd2c3-18fe-4772-8a16-746285d8ff9f.png)

## Ссылка на задачу
[pro-press-hero-title](https://www.notion.so/for-press-hero-title-c272d44bf81b4a528d6df9025f2f5a41)

## Вопросы / TODO: 

UPD 28.10
Ошибки Typescript больше не наблюдается

1. есть ошибка TypeScript в stories, у `data` (думаю, как пофиксить)
```
Default.args = {
  data: mockData,
};
```

> Type '{}' is missing the following properties from type '{ title: string; description: string; link: string; }': title, description, linkts(2739)

2. в целом пока сложность представить резиновость сайта. Использовала миксины, в которых прописан sсale. И вот на 749px например есть такой перепад в размере между заголовком  и основным текстом. 

![Снимок экрана 2021-10-24 в 22 51 52](https://user-images.githubusercontent.com/76454288/138610457-0b3862a6-b377-42b2-815f-0a1918f3be68.png)

UPD 31.10 
Рефакторинг: для более верной верстки хироу секции страницы разбила текущий компонент на два компонента: hero-title и hero-description. 