### PR TITLE
History page fix

### DIFF
--- a/src/components/ui/menu/type/history.module.css
+++ b/src/components/ui/menu/type/history.module.css
@@ -7,7 +7,8 @@
   scroll-behavior: smooth;
 
   &::-webkit-scrollbar {
-    width: scale(0);
+    width: 0;
+    height: 0;
   }
 }
 

--- a/src/components/ui/menu/type/history.module.css
+++ b/src/components/ui/menu/type/history.module.css
@@ -1,8 +1,14 @@
 .menu {
   display: flex;
+  overflow: auto;
   align-items: center;
   padding: 0;
   margin: 0;
+  scroll-behavior: smooth;
+
+  &::-webkit-scrollbar {
+    width: scale(0);
+  }
 }
 
 .item {


### PR DESCRIPTION
## Описание
Исправление ошибки - не работал скролл на странице History в компоненте Menu.

## Ссылка на задачу
[Добавить скролл в компонент Menu для использования на странице History](https://www.notion.so/front-52aae4efcc1743f58f4abf64bf7357ff?p=702d44226fc14dfab3f578e93788d3b6)
