### PR TITLE
For press hero pr contact

### DIFF
--- a/src/components/for-press-hero-pr-contact/assets/mock-data.json
+++ b/src/components/for-press-hero-pr-contact/assets/mock-data.json
@@ -1,0 +1,7 @@
+{
+  "name": "Анна Загородникова",
+  "nameDative": "Анне Загородниковой",
+  "email": "annaszagorodnikova@gmail.com",
+  "description": "PR-директор фестиваля, координатор по связям со СМИ",
+  "photo": "https://lubimovka.ru/images/2018material/photos/resizedimages/1.jpg"
+}

--- a/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.module.css
+++ b/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.module.css
@@ -1,0 +1,65 @@
+.intro {
+  @mixin headline;
+  @mixin headline6;
+
+  max-width: 387px;
+
+  @media (max-width: $tablet-portrait) {
+    max-width: 366px;
+  }
+
+  @media (min-width: $desktop) {
+    max-width: scale(387px);
+  }
+}
+
+.photo {
+  width: 150px;
+  height: 182px;
+  margin: 25px auto 32px 31px;
+  object-fit: cover;
+
+  @media (max-width: $tablet-portrait) {
+    margin: 24px auto 24px 63px;
+  }
+
+  @media (min-width: $desktop) {
+    width: scale(150px);
+    height: scale(182px);
+    margin: scale(25px auto 32px 31px);
+  }
+}
+
+.info {
+  margin: 0;
+}
+
+.email {
+  max-width: 479px;
+  margin: 0;
+  margin-bottom: 8px;
+
+  @media (max-width: $tablet-portrait) {
+    max-width: 367px;
+  }
+
+  @media (min-width: $desktop) {
+    max-width: scale(479px);
+    margin-bottom: scale(8px);
+  }
+}
+
+.description {
+  @mixin text;
+  @mixin textSmall;
+
+  max-width: 269px;
+
+  @media (min-width: $desktop) {
+    max-width: scale(269px);
+  }
+}
+
+.hiddenText {
+  @mixin visually-hidden;
+}

--- a/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.stories.tsx
+++ b/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { ForPressHeroPrContact } from './for-press-hero-pr-contact';
+import mockData from './assets/mock-data.json';
+
+export default {
+  title: 'Components/ForPressHeroPrContact',
+  component: ForPressHeroPrContact,
+
+} as ComponentMeta<typeof ForPressHeroPrContact>;
+
+const Template: ComponentStory<typeof ForPressHeroPrContact> = (args) => {
+  return <ForPressHeroPrContact {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  data: mockData,
+};

--- a/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.tsx
+++ b/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.tsx
@@ -1,0 +1,50 @@
+import {FC} from 'react';
+import cn from 'classnames/bind';
+
+import styles from './for-press-hero-pr-contact.module.css';
+import { Url } from 'shared/types';
+import { InfoLink } from 'components/ui/info-link';
+
+const cx = cn.bind(styles);
+
+export interface IForPressHeroPrContact {
+  data: {
+    name: string,
+    nameDative: string,
+    email: string,
+    description: string,
+    photo: Url,
+   },
+}
+
+export const ForPressHeroPrContact: FC<IForPressHeroPrContact> = ({ data }) => {
+
+  return (
+    <section>
+      <h6 className={cx('intro')}>
+        По вопросам PR и аккредитации пишите {data.nameDative}
+      </h6>
+      <img className={cx('photo')} src={data.photo} alt={data.name} />
+      <dl className={cx('info')}>
+        <dt className={cx('hiddenText')}>
+          Email:
+        </dt>
+        <dd className={cx('email')}>
+          <InfoLink
+            isOutsideLink={true}
+            href={`mailto://${data.email}`}
+            label={data.email}
+            size= 'l'
+            textDecoration='underline'
+          />
+        </dd>
+        <dt className={cx('hiddenText')}>
+          Должность:
+        </dt>
+        <dd className={cx('description')}>
+          {data.description}
+        </dd>
+      </dl>
+    </section>
+  );
+};

--- a/src/components/for-press-hero-pr-contact/index.tsx
+++ b/src/components/for-press-hero-pr-contact/index.tsx
@@ -1,0 +1,1 @@
+export * from './for-press-hero-pr-contact';

--- a/src/components/project-header/project-header.module.css
+++ b/src/components/project-header/project-header.module.css
@@ -44,7 +44,6 @@
   @media (max-width: $tablet-portrait) {
     @mixin headline7;
 
-
     max-width: scale(304px);
     margin: scale(0 24px 36px auto);
   }


### PR DESCRIPTION
## Описание
Компонент страницы Для прессы рендерит информацию о PR-контактах фестиваля. 

![Снимок экрана 2021-10-30 в 15 44 31](https://user-images.githubusercontent.com/76454288/139533315-23612d06-13b7-4a20-9699-7b9379ee1fa6.png)



## Ссылка на задачу
[Компонент for-press-hero-pr-contact](https://www.notion.so/for-press-hero-pr-contact-eacbe912b7e64e7481e299390fedded2)


## Вопросы и комментарии
Резиновость прописываю от 1440px, но в целом пока по шрифтам все некрасиво едет, похоже из-за того, что подход не унифицирован. 

Использовала семантические теги` dl, dt, dd`. Как считаете, обоснованно ли? 

В целом предлагаем, что информация в целом статичная, но на всякий случай все же прописываю, что информации о персоне может меняться. Как считаете, не нужно ли весь текст просто захардкодить? 