### PR TITLE
News card

### DIFF
--- a/src/components/ui/news-card/index.ts
+++ b/src/components/ui/news-card/index.ts
@@ -1,0 +1,1 @@
+export * from './news-card';

--- a/src/components/ui/news-card/news-card.module.css
+++ b/src/components/ui/news-card/news-card.module.css
@@ -1,0 +1,52 @@
+.wrapper {
+  display: flex;
+  justify-content: space-between;
+  padding: scale(16px 11px 64px 21px);
+  border-top: 1px solid var(--coal);
+  border-bottom: 1px solid var(--coal);
+  text-decoration: none;
+  transition: background-color .5s ease-in, color .5s ease-in;
+
+  &:hover {
+    background-color: var(--light-green);
+  }
+
+  @media (max-width: $tablet-portrait) {
+    flex-direction: column-reverse;
+    padding: scale(16px 0 48px);
+  }
+}
+
+.title {
+  @mixin headline;
+  @mixin headline5;
+
+  max-width: scale(681px);
+
+  @media (max-width: $tablet-portrait) {
+    @mixin headline6;
+
+    max-width: scale(316px);
+  }
+}
+
+.description {
+  @mixin text;
+  @mixin textLarge;
+
+  max-width: scale(491px);
+  padding: scale(8px 0 0 32px);
+
+  @media (max-width: $tablet-portrait) {
+    max-width: scale(333px);
+  }
+}
+
+.date {
+  @mixin text;
+  @mixin textSmall;
+
+  @media (max-width: $tablet-portrait) {
+    padding-bottom: scale(16px);
+  }
+}

--- a/src/components/ui/news-card/news-card.module.css
+++ b/src/components/ui/news-card/news-card.module.css
@@ -17,6 +17,14 @@
   }
 }
 
+.mainPageWrapper {
+  flex-direction: column;
+
+  @media (max-width: $tablet-portrait) {
+    padding: 16px 0 72px;
+  }
+}
+
 .title {
   @mixin headline;
   @mixin headline5;
@@ -27,6 +35,16 @@
     @mixin headline6;
 
     max-width: scale(316px);
+  }
+}
+
+.mainPageTitle {
+  max-width: 681px;
+
+  @media (max-width: $tablet-portrait) {
+    @mixin headline5;
+
+    max-width: 336px;
   }
 }
 
@@ -42,6 +60,14 @@
   }
 }
 
+.mainPageDescription {
+  max-width: 491px;
+
+  @media (max-width: $tablet-portrait) {
+    max-width: 304px;
+  }
+}
+
 .date {
   @mixin text;
   @mixin textSmall;
@@ -49,4 +75,9 @@
   @media (max-width: $tablet-portrait) {
     padding-bottom: scale(16px);
   }
+}
+
+.mainPageDate {
+  padding-top: 16px;
+  padding-bottom: 0;
 }

--- a/src/components/ui/news-card/news-card.module.css
+++ b/src/components/ui/news-card/news-card.module.css
@@ -20,7 +20,7 @@
   flex-direction: column;
 
   @media (max-width: $tablet-portrait) {
-    padding: 16px 0 72px;
+    padding: scale(16px 0 72px);
   }
 }
 
@@ -43,7 +43,7 @@
   @media (max-width: $tablet-portrait) {
     @mixin headline5;
 
-    max-width: 336px;
+    max-width: scale(336px);
   }
 }
 
@@ -60,10 +60,10 @@
 }
 
 .mainPageDescription {
-  max-width: 491px;
+  max-width: scale(491px);
 
   @media (max-width: $tablet-portrait) {
-    max-width: 304px;
+    max-width: scale(304px);
   }
 }
 
@@ -77,6 +77,6 @@
 }
 
 .mainPageDate {
-  padding-top: 16px;
+  padding-top: scale(16px);
   padding-bottom: 0;
 }

--- a/src/components/ui/news-card/news-card.module.css
+++ b/src/components/ui/news-card/news-card.module.css
@@ -3,7 +3,6 @@
   justify-content: space-between;
   padding: scale(16px 11px 64px 21px);
   border-top: 1px solid var(--coal);
-  border-bottom: 1px solid var(--coal);
   text-decoration: none;
   transition: background-color .5s ease-in, color .5s ease-in;
 

--- a/src/components/ui/news-card/news-card.stories.tsx
+++ b/src/components/ui/news-card/news-card.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import NewsCard from './news-card';
+
+export default {
+  title: 'UI/NewsCard',
+  component: NewsCard,
+
+} as ComponentMeta<typeof NewsCard>;
+
+const Template: ComponentStory<typeof NewsCard> = (args) => <NewsCard {...args}/>;
+
+export const News = Template.bind({});
+News.args = {
+  newsId: 1,
+  title: 'Дизайн Любимовки-2021',
+  description: 'Присылайте ваши варианты текстовых описаний.',
+  date: '2015-02-24T21:23',
+};
+
+News.parameters = {
+  layout: 'fullscreen',
+};

--- a/src/components/ui/news-card/news-card.stories.tsx
+++ b/src/components/ui/news-card/news-card.stories.tsx
@@ -16,8 +16,23 @@ News.args = {
   title: 'Дизайн Любимовки-2021',
   description: 'Присылайте ваши варианты текстовых описаний.',
   date: '2015-02-24T21:23',
+  isMainPage: false
 };
 
 News.parameters = {
+  layout: 'fullscreen',
+};
+
+export const NewsMainPage = Template.bind({});
+
+NewsMainPage.args = {
+  newsId: 1,
+  title: 'Дизайн Любимовки-2021',
+  description: 'Присылайте ваши варианты текстовых описаний.',
+  date: '2015-02-24T21:23',
+  isMainPage: true
+};
+
+NewsMainPage.parameters = {
   layout: 'fullscreen',
 };

--- a/src/components/ui/news-card/news-card.tsx
+++ b/src/components/ui/news-card/news-card.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Link from 'next/link';
+
+import cn from 'classnames/bind';
+
+import styles from './news-card.module.css';
+
+const cx = cn.bind(styles);
+
+export interface INewsCardProps {
+  newsId: number;
+  title: string;
+  description: string;
+  date: string;
+}
+
+export const NewsCard: React.FC<INewsCardProps> = (props) => {
+  const {
+    newsId,
+    title,
+    description,
+    date,
+  } = props;
+
+  return (
+    <Link href={`/news/${encodeURIComponent(newsId)}`}>
+      <a className={cx('wrapper')}>
+        <div className={cx('container')}>
+          <h5 className={cx('title')}>{title}</h5>
+          <p className={cx('description')}>{description}</p>
+        </div>
+        <p className={cx('date')}>{new Date(date).toLocaleDateString('ru-Ru', {month: 'long', day:'numeric', year:'numeric'}).replace(' г.', '')}</p>
+      </a>
+    </Link>
+  );
+};
+
+export default NewsCard;

--- a/src/components/ui/news-card/news-card.tsx
+++ b/src/components/ui/news-card/news-card.tsx
@@ -12,6 +12,7 @@ export interface INewsCardProps {
   title: string;
   description: string;
   date: string;
+  isMainPage: boolean;
 }
 
 export const NewsCard: React.FC<INewsCardProps> = (props) => {
@@ -20,16 +21,17 @@ export const NewsCard: React.FC<INewsCardProps> = (props) => {
     title,
     description,
     date,
+    isMainPage
   } = props;
 
   return (
     <Link href={`/news/${encodeURIComponent(newsId)}`}>
-      <a className={cx('wrapper')}>
+      <a className={cx('wrapper', {mainPageWrapper: isMainPage})}>
         <div className={cx('container')}>
-          <h5 className={cx('title')}>{title}</h5>
-          <p className={cx('description')}>{description}</p>
+          <h5 className={cx('title', {mainPageTitle: isMainPage})}>{title}</h5>
+          <p className={cx('description', {mainPageDescription: isMainPage})}>{description}</p>
         </div>
-        <p className={cx('date')}>{new Date(date).toLocaleDateString('ru-Ru', {month: 'long', day:'numeric', year:'numeric'}).replace(' г.', '')}</p>
+        <p className={cx('date', {mainPageDate: isMainPage})}>{new Date(date).toLocaleDateString('ru-Ru', {month: 'long', day:'numeric', year:'numeric'}).replace(' г.', '')}</p>
       </a>
     </Link>
   );

--- a/src/components/ui/news-card/news-card.tsx
+++ b/src/components/ui/news-card/news-card.tsx
@@ -13,6 +13,7 @@ export interface INewsCardProps {
   description: string;
   date: string;
   isMainPage: boolean;
+  className?: string;
 }
 
 export const NewsCard: React.FC<INewsCardProps> = (props) => {
@@ -21,12 +22,13 @@ export const NewsCard: React.FC<INewsCardProps> = (props) => {
     title,
     description,
     date,
-    isMainPage
+    isMainPage,
+    className
   } = props;
 
   return (
     <Link href={`/news/${encodeURIComponent(newsId)}`}>
-      <a className={cx('wrapper', {mainPageWrapper: isMainPage})}>
+      <a className={cx('wrapper', {mainPageWrapper: isMainPage}, [className])}>
         <div className={cx('container')}>
           <h5 className={cx('title', {mainPageTitle: isMainPage})}>{title}</h5>
           <p className={cx('description', {mainPageDescription: isMainPage})}>{description}</p>


### PR DESCRIPTION
## Описание
### Карточка новости для страниц News и Main
**Desktop:** 
![Screenshot from 2021-11-01 07-16-27](https://user-images.githubusercontent.com/79516696/139621014-ba747590-7978-4766-9e74-c94322a77580.png)

**Mobile:**
![Screenshot from 2021-11-01 07-16-43](https://user-images.githubusercontent.com/79516696/139621029-90001c26-22be-4567-a634-a4181d48f629.png)

**Main:**
![Screenshot from 2021-11-01 07-16-57](https://user-images.githubusercontent.com/79516696/139621070-cee275b9-2448-4e3e-9dc5-fd5644a39f22.png)

- Ширина карточки задается родительским блоком. 
- На страницу новостей планирую вставлять их через ul > li. 
- Вся карточка является ссылкой. 
- Анимация сделана по аналогии с анимацией ссылок в InfoLink.
- На главной странице положение и размеры элементов отличаются от обычной карточки (дата переезжает вниз), поэтому добавила переключатель isMainPage. 
- Есть возможность прокидывать собственный класс.

## Ссылка на задачу
[News-Card](https://www.notion.so/front-52aae4efcc1743f58f4abf64bf7357ff?p=0c00bc0d3ea041d98bb3d5469c2d044f)
