### PR TITLE
fix: Rename scale

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
 const path = require('path');
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
 const breakpoints = require('./src/shared/breakpoints');
-const scale = require('./src/shared/helpers/scale')();
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
+const scaleSize = require('./src/shared/helpers/scaleSize')();
+
+// eslint-disable-next-line no-undef
 module.exports = {
   plugins: [
     'postcss-flexbugs-fixes',
@@ -21,6 +26,7 @@ module.exports = {
     [
       'postcss-mixins',
       {
+        // eslint-disable-next-line no-undef
         mixinsDir: path.join(__dirname, 'src/shared/styles/mixins'),
       }
     ],
@@ -35,7 +41,7 @@ module.exports = {
       'postcss-functions',
       {
         functions: {
-          scale,
+          scaleSize,
         },
       }
     ]

--- a/src/components/article-share/article-share.module.css
+++ b/src/components/article-share/article-share.module.css
@@ -38,9 +38,9 @@
   }
 
   @media (min-width: $desktop) {
-    padding-top: scale(72px);
-    padding-bottom: scale(59px);
-    padding-left: calc(50% - scale(450px));
+    padding-top: scalesize(72px);
+    padding-bottom: scalesize(59px);
+    padding-left: calc(50% - scalesize(450px));
   }
 }
 
@@ -52,8 +52,8 @@
   padding-bottom: 2px;
 
   @media (min-width: $desktop) {
-    max-width: scale(420px);
-    padding-bottom: scale(2px);
+    max-width: scalesize(420px);
+    padding-bottom: scalesize(2px);
   }
 }
 
@@ -66,8 +66,8 @@
   word-break: break-word;
 
   @media (min-width: $desktop) {
-    max-width: scale(390px);
-    padding-left: scale(30px);
+    max-width: scalesize(390px);
+    padding-left: scalesize(30px);
   }
 }
 
@@ -75,7 +75,7 @@
   padding-bottom: 32px;
 
   @media (min-width: $desktop) {
-    padding-bottom: scale(32px);
+    padding-bottom: scalesize(32px);
   }
 }
 
@@ -95,7 +95,7 @@
   }
 
   @media (min-width: $desktop) {
-    padding-left: scale(24px);
+    padding-left: scalesize(24px);
   }
 }
 
@@ -110,9 +110,9 @@
   }
 
   @media (min-width: $desktop) {
-    padding-top: scale(51px);
-    padding-bottom: scale(85px);
-    padding-left: scale(180px);
+    padding-top: scalesize(51px);
+    padding-bottom: scalesize(85px);
+    padding-left: scalesize(180px);
   }
 }
 
@@ -134,7 +134,7 @@
   }
 
   @media (min-width: $desktop) {
-    width: scale(420px);
+    width: scalesize(420px);
   }
 }
 
@@ -153,7 +153,7 @@
   }
 
   @media (min-width: $desktop) {
-    top: scale(9px);
-    left: scale(231px);
+    top: scalesize(9px);
+    left: scalesize(231px);
   }
 }

--- a/src/components/article-title/article-title.module.css
+++ b/src/components/article-title/article-title.module.css
@@ -1,9 +1,9 @@
 .container {
   display: grid;
   box-sizing: border-box;
-  padding: scale(32px 0 0 30px);
+  padding: scalesize(32px 0 0 30px);
   margin: 0 auto;
-  grid-column-gap: scale(30px);
+  grid-column-gap: scalesize(30px);
   grid-template-areas:
     'button a a a'
     'b title title c'
@@ -12,7 +12,7 @@
   grid-template-columns: min-content 1fr 1fr 2.555fr;
 
   @media (max-width: $tablet-portrait) {
-    padding: scale(32px 0 0 24px);
+    padding: scalesize(32px 0 0 24px);
     grid-template-areas:
       'button'
       'img'
@@ -28,7 +28,7 @@
   grid-area: button;
 
   @media (max-width: $tablet-portrait) {
-    left: scale(60px);
+    left: scalesize(60px);
   }
 }
 
@@ -36,15 +36,15 @@
   @mixin headline;
   @mixin headline3;
 
-  max-width: scale(570px);
-  margin-top: scale(18px);
+  max-width: scalesize(570px);
+  margin-top: scalesize(18px);
   grid-area: title;
   word-break: break-word;
 
   @media (max-width: $tablet-portrait) {
     @mixin headline4;
 
-    max-width: scale(366px);
+    max-width: scalesize(366px);
   }
 }
 
@@ -52,17 +52,17 @@
   @mixin headline;
   @mixin headline6;
 
-  max-width: scale(480px);
-  margin-top: scale(22px);
-  margin-left: scale(60px);
+  max-width: scalesize(480px);
+  margin-top: scalesize(22px);
+  margin-left: scalesize(60px);
   grid-area: description;
   word-break: break-word;
 
   @media (max-width: $tablet-portrait) {
     @mixin headline7;
 
-    max-width: scale(305px);
-    margin-top: scale(22px);
+    max-width: scalesize(305px);
+    margin-top: scalesize(22px);
   }
 }
 
@@ -75,14 +75,14 @@
   justify-self: center;
 
   @media (max-width: $tablet-portrait) {
-    padding-top: scale(24px);
-    padding-left: scale(60px);
+    padding-top: scalesize(24px);
+    padding-left: scalesize(60px);
     justify-self: start;
   }
 }
 
 .dateNews {
-  padding-left: scale(60px);
+  padding-left: scalesize(60px);
 }
 
 .author {
@@ -91,21 +91,21 @@
   justify-self: center;
 
   @media (max-width: $tablet-portrait) {
-    margin: scale(24px 0 75px 60px) !important;
+    margin: scalesize(24px 0 75px 60px) !important;
     justify-self: start;
   }
 }
 
 .img {
   width: 100%;
-  max-height: scale(421px);
-  padding-top: scale(30px);
+  max-height: scalesize(421px);
+  padding-top: scalesize(30px);
   grid-area: img;
   object-fit: cover;
 
   @media (max-width: $tablet-portrait) {
-    max-height: scale(218px);
-    padding-top: scale(40px);
-    padding-left: scale(30px);
+    max-height: scalesize(218px);
+    padding-top: scalesize(40px);
+    padding-left: scalesize(30px);
   }
 }

--- a/src/components/creators-list/creators-list.module.css
+++ b/src/components/creators-list/creators-list.module.css
@@ -8,7 +8,7 @@
   @mixin text;
   @mixin textSmall;
 
-  margin-top: scale(24px);
+  margin-top: scalesize(24px);
 
   &:first-of-type {
     margin-top: 0;
@@ -19,13 +19,13 @@
   @mixin text;
   @mixin textLarge;
 
-  margin-left: scale(28px);
+  margin-left: scalesize(28px);
 
   &:last-of-type {
-    width: scale(420px);
+    width: scalesize(420px);
 
     @media (max-width: $tablet-portrait) {
-      width: scale(337px);
+      width: scalesize(337px);
     }
   }
 }

--- a/src/components/event-card/event-card.module.css
+++ b/src/components/event-card/event-card.module.css
@@ -1,20 +1,20 @@
 .card {
   display: grid;
-  padding-bottom: scale(48px);
-  gap: scale(16px) 0;
+  padding-bottom: scalesize(48px);
+  gap: scalesize(16px) 0;
   grid-template:
     "time-location image"
     "title         title"
     "description   description"
     "credits       credits"
-    "actions       actions" 1fr / 1fr minmax(0, scale(127px));
+    "actions       actions" 1fr / 1fr minmax(0, scalesize(127px));
 
   @media (min-width: $tablet-portrait) {
     padding: 0;
-    gap: scale(16px) scale(32px);
+    gap: scalesize(16px) scalesize(32px);
     grid-template:
       "image time-location title       .       ."
-      "image time-location description credits actions" 1fr / minmax(0, scale(147px)) minmax(0, 12.5%) minmax(0, 27.5%) minmax(0, 30%) minmax(0, 17.5%);
+      "image time-location description credits actions" 1fr / minmax(0, scalesize(147px)) minmax(0, 12.5%) minmax(0, 27.5%) minmax(0, 30%) minmax(0, 17.5%);
   }
 }
 
@@ -22,7 +22,7 @@
   grid-area: image;
 
   @media (min-width: $tablet-portrait) {
-    margin-right: scale(-4px);
+    margin-right: scalesize(-4px);
   }
 }
 
@@ -46,12 +46,12 @@
   @mixin headline6;
 
   @media (min-width: $tablet-portrait) {
-    margin-top: scale(15px);
+    margin-top: scalesize(15px);
   }
 }
 
 .timeLocation {
-  padding-right: scale(8px);
+  padding-right: scalesize(8px);
   margin: 0;
   grid-area: time-location;
 
@@ -68,12 +68,12 @@
   @mixin headline;
   @mixin headline7;
 
-  margin-top: scale(19px);
+  margin-top: scalesize(19px);
 
   @media (min-width: $tablet-portrait) {
     @mixin headline6;
 
-    margin-top: scale(15px);
+    margin-top: scalesize(15px);
   }
 }
 
@@ -82,7 +82,7 @@
   @mixin textSmall;
 
   @media (min-width: $tablet-portrait) {
-    margin: scale(16px) 0 0;
+    margin: scalesize(16px) 0 0;
   }
 }
 
@@ -90,12 +90,12 @@
   @mixin text;
   @mixin textSmall;
 
-  margin: 0 0 scale(8px) scale(64px);
+  margin: 0 0 scalesize(8px) scalesize(64px);
   grid-area: description;
   word-wrap: break-word;
 
   @media (min-width: $tablet-portrait) {
-    margin: 0 0 scale(44px);
+    margin: 0 0 scalesize(44px);
   }
 }
 

--- a/src/components/footer/address/footer-address.module.css
+++ b/src/components/footer/address/footer-address.module.css
@@ -1,7 +1,7 @@
 @value partners from '../partners/footer-partners.module.css';
 
 .address {
-  margin-top: scale(50px);
+  margin-top: scalesize(50px);
   font-style: normal;
   grid-area: address;
   white-space: pre;
@@ -9,8 +9,8 @@
   @media (max-width: $tablet-portrait) {
     @mixin textSmall;
 
-    padding: scale(0 55px);
-    margin-top: scale(33px);
+    padding: scalesize(0 55px);
+    margin-top: scalesize(33px);
   }
 
   span {
@@ -18,14 +18,14 @@
     @mixin headline7;
 
     display: block;
-    margin-bottom: scale(16px);
+    margin-bottom: scalesize(16px);
 
     @media (max-width: $tablet-portrait) {
-      margin-bottom: scale(8px);
+      margin-bottom: scalesize(8px);
     }
   }
 }
 
 .partners ~ .address {
-  margin-top: scale(62px);
+  margin-top: scalesize(62px);
 }

--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -3,11 +3,11 @@
   @mixin textCaption;
 
   display: grid;
-  padding: scale(42px 32px 56px);
+  padding: scalesize(42px 32px 56px);
   grid-template:
     "logo partners partners   partners"
     "logo address  navigation projects"
-    "logo footnote footnote   footnote" 1fr / min-content 1fr scale(360px) scale(244px);
+    "logo footnote footnote   footnote" 1fr / min-content 1fr scalesize(360px) scalesize(244px);
 
   @media (max-width: $tablet-portrait) {
     @mixin textMedium;
@@ -24,37 +24,37 @@
 }
 
 .logo {
-  width: scale(93px);
-  height: scale(80px);
-  margin-right: scale(82px);
+  width: scalesize(93px);
+  height: scalesize(80px);
+  margin-right: scalesize(82px);
   grid-area: logo;
 
   @media (max-width: $tablet-portrait) {
     margin-right: 0;
-    margin-left: scale(58px);
+    margin-left: scalesize(58px);
   }
 }
 
 .footnote {
   display: flex;
-  margin-top: scale(49px);
+  margin-top: scalesize(49px);
   grid-area: footnote;
 
   @media (max-width: $tablet-portrait) {
     @mixin textCaption;
 
     flex-direction: column;
-    padding: scale(32px 28px 74px);
+    padding: scalesize(32px 28px 74px);
     border-top: 1px solid black;
-    margin-top: scale(70px);
+    margin-top: scalesize(70px);
   }
 }
 
 .copyright {
-  margin: scale(0 32px 0 0);
+  margin: scalesize(0 32px 0 0);
 
   @media (max-width: $tablet-portrait) {
-    margin: scale(0 0 10px 0);
+    margin: scalesize(0 0 10px 0);
   }
 }
 
@@ -69,13 +69,13 @@
 
 .credits {
   display: flex;
-  width: scale(424px);
+  width: scalesize(424px);
   margin: 0 0 0 auto;
 
   @media (max-width: $tablet-portrait) {
-    width: scale(254px);
+    width: scalesize(254px);
     flex-direction: column;
-    margin: scale(59px 0 0 0);
+    margin: scalesize(59px 0 0 0);
   }
 
   dt {
@@ -92,21 +92,21 @@
 
 .shishki {
   display: grid;
-  margin-right: scale(38px);
+  margin-right: scalesize(38px);
   grid-template:
     "logo text"
     "logo text" 1fr / min-content 1fr;
 
   @media (max-width: $tablet-portrait) {
     margin-right: 0;
-    margin-bottom: scale(16px);
+    margin-bottom: scalesize(16px);
   }
 
   &::before {
     display: block;
-    width: scale(27px);
-    height: scale(25px);
-    margin-right: scale(4px);
+    width: scalesize(27px);
+    height: scalesize(25px);
+    margin-right: scalesize(4px);
     background-image: url('./footer.assets/shishki.svg');
     background-repeat: no-repeat;
     background-size: contain;
@@ -114,8 +114,8 @@
     grid-area: logo;
 
     @media (max-width: $tablet-portrait) {
-      margin-top: scale(6px);
-      margin-right: scale(9px);
+      margin-top: scalesize(6px);
+      margin-right: scalesize(9px);
     }
   }
 }

--- a/src/components/footer/navigation/footer-navigation.module.css
+++ b/src/components/footer/navigation/footer-navigation.module.css
@@ -1,17 +1,17 @@
 @value partners from '../partners/footer-partners.module.css';
 
 .navigation {
-  margin-top: scale(50px);
-  margin-right: scale(56px);
+  margin-top: scalesize(50px);
+  margin-right: scalesize(56px);
   grid-area: navigation;
 
   @media (max-width: $tablet-portrait) {
-    padding: scale(0 55px);
-    margin-top: scale(56px);
+    padding: scalesize(0 55px);
+    margin-top: scalesize(56px);
     margin-right: 0;
   }
 }
 
 .partners ~ .navigation {
-  margin-top: scale(62px);
+  margin-top: scalesize(62px);
 }

--- a/src/components/footer/partner-list-item/footer-partner-list-item.module.css
+++ b/src/components/footer/partner-list-item/footer-partner-list-item.module.css
@@ -7,11 +7,11 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: scale(0 15px);
+    padding: scalesize(0 15px);
   }
 
   &:not(:last-child) {
-    margin-right: scale(28px);
+    margin-right: scalesize(28px);
 
     @media (max-width: $tablet-portrait) {
       margin-right: 0;
@@ -21,8 +21,8 @@
 
 .logoCanvas {
   position: relative;
-  width: scale(100px);
-  height: scale(40px);
+  width: scalesize(100px);
+  height: scalesize(40px);
 }
 
 .logo {

--- a/src/components/footer/partner-list/footer-partner-list.module.css
+++ b/src/components/footer/partner-list/footer-partner-list.module.css
@@ -5,8 +5,8 @@
 
   @media (max-width: $tablet-portrait) {
     display: grid;
-    padding: scale(30px 24px 0);
-    grid-auto-rows: scale(118px);
-    grid-template-columns: repeat(2, scale(182px));
+    padding: scalesize(30px 24px 0);
+    grid-auto-rows: scalesize(118px);
+    grid-template-columns: repeat(2, scalesize(182px));
   }
 }

--- a/src/components/footer/partners/footer-partners.module.css
+++ b/src/components/footer/partners/footer-partners.module.css
@@ -7,7 +7,7 @@
   display: flex;
   max-width: 10ch;
   align-items: flex-end;
-  margin-right: scale(56px);
+  margin-right: scalesize(56px);
 
   @media (max-width: $tablet-portrait) {
     display: none;

--- a/src/components/footer/projects/footer-projects.module.css
+++ b/src/components/footer/projects/footer-projects.module.css
@@ -1,16 +1,16 @@
 @value partners from '../partners/footer-partners.module.css';
 
 .projects {
-  margin-top: scale(50px);
+  margin-top: scalesize(50px);
   grid-area: projects;
 
   @media (max-width: $tablet-portrait) {
-    padding: scale(0 55px);
-    margin-top: scale(46px);
-    margin-bottom: scale(36px);
+    padding: scalesize(0 55px);
+    margin-top: scalesize(46px);
+    margin-bottom: scalesize(36px);
   }
 }
 
 .partners ~ .projects {
-  margin-top: scale(62px);
+  margin-top: scalesize(62px);
 }

--- a/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.module.css
+++ b/src/components/for-press-hero-pr-contact/for-press-hero-pr-contact.module.css
@@ -9,7 +9,7 @@
   }
 
   @media (min-width: $desktop) {
-    max-width: scale(387px);
+    max-width: scalesize(387px);
   }
 }
 
@@ -24,9 +24,9 @@
   }
 
   @media (min-width: $desktop) {
-    width: scale(150px);
-    height: scale(182px);
-    margin: scale(25px auto 32px 31px);
+    width: scalesize(150px);
+    height: scalesize(182px);
+    margin: scalesize(25px auto 32px 31px);
   }
 }
 
@@ -44,8 +44,8 @@
   }
 
   @media (min-width: $desktop) {
-    max-width: scale(479px);
-    margin-bottom: scale(8px);
+    max-width: scalesize(479px);
+    margin-bottom: scalesize(8px);
   }
 }
 
@@ -56,7 +56,7 @@
   max-width: 269px;
 
   @media (min-width: $desktop) {
-    max-width: scale(269px);
+    max-width: scalesize(269px);
   }
 }
 

--- a/src/components/logotype/logotype.module.css
+++ b/src/components/logotype/logotype.module.css
@@ -5,6 +5,6 @@
 }
 
 .image {
-  width: scale(43px);
-  height: scale(35px);
+  width: scalesize(43px);
+  height: scalesize(35px);
 }

--- a/src/components/main-page/archive/main-archive.module.css
+++ b/src/components/main-page/archive/main-archive.module.css
@@ -1,100 +1,100 @@
 .archive {
   width: 100%;
-  padding-top: scale(68px);
-  padding-bottom: scale(108px);
+  padding-top: scalesize(68px);
+  padding-bottom: scalesize(108px);
   background-color: var(--light-green);
   grid-area: archive;
 }
 
 .content {
   width: 100%;
-  max-width: scale(866px);
-  margin-bottom: scale(14px);
+  max-width: scalesize(866px);
+  margin-bottom: scalesize(14px);
 }
 
 .title {
   @mixin headline;
   @mixin headline2;
 
-  margin-bottom: scale(18px);
-  margin-left: scale(150px);
+  margin-bottom: scalesize(18px);
+  margin-left: scalesize(150px);
 }
 
 .text {
   display: inline-block;
   overflow: hidden;
-  max-width: scale(480px);
-  margin: scale(0);
+  max-width: scalesize(480px);
+  margin: scalesize(0);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .link {
   position: relative;
-  bottom: scale(42px);
+  bottom: scalesize(42px);
   display: inline-block;
-  margin: scale(0 20px 0 6px);
+  margin: scalesize(0 20px 0 6px);
 }
 
 .desc {
   @mixin text;
   @mixin textLarge;
 
-  max-width: scale(432px);
-  margin-left: scale(210px);
+  max-width: scalesize(432px);
+  margin-left: scalesize(210px);
 }
 
 .video {
   width: 100%;
   max-width: 33.75rem;
   height: 16.125rem;
-  margin: scale(0) auto;
+  margin: scalesize(0) auto;
 }
 
 @media (min-width: $desktop) {
   .video {
-    max-width: scale(540px);
-    height: scale(258px);
+    max-width: scalesize(540px);
+    height: scalesize(258px);
   }
 }
 
 @media (max-width: $tablet-portrait) {
   .archive {
-    padding-top: scale(75px);
-    padding-bottom: scale(100px);
+    padding-top: scalesize(75px);
+    padding-bottom: scalesize(100px);
   }
 
   .title {
     @mixin headline4;
 
-    margin-left: scale(24px);
+    margin-left: scalesize(24px);
   }
 
   .text {
-    max-width: scale(260px);
+    max-width: scalesize(260px);
     text-overflow: clip;
   }
 
   .link {
-    bottom: scale(32px);
+    bottom: scalesize(32px);
     display: inline-block;
-    margin: scale(0);
-    margin-left: scale(2px);
+    margin: scalesize(0);
+    margin-left: scalesize(2px);
   }
 
   .desc {
-    margin: scale(0 24px 34px 85px);
+    margin: scalesize(0 24px 34px 85px);
   }
 
   .video {
-    margin-right: scale(0);
+    margin-right: scalesize(0);
     margin-left: auto;
   }
 }
 
 @media (max-width: 415px) {
   .video {
-    max-width: scale(540px);
-    height: scale(258px);
+    max-width: scalesize(540px);
+    height: scalesize(258px);
   }
 }

--- a/src/components/main-page/main-page.module.css
+++ b/src/components/main-page/main-page.module.css
@@ -5,7 +5,7 @@
   width: 100%;
   min-width: var(--page-content-min-width);
   box-sizing: border-box;
-  padding-top: scale(61px);
+  padding-top: scalesize(61px);
   margin: 0 auto;
   grid-template-areas:
     "title title"
@@ -15,7 +15,7 @@
     "shortList ."
     "archive archive"
     "partners .";
-  grid-template-columns: minmax(scale(500px), scale(1110px)) 1fr;
+  grid-template-columns: minmax(scalesize(500px), scalesize(1110px)) 1fr;
   grid-template-rows: repeat(6, max-content);
 
   @media screen and (max-width: 1200px) {

--- a/src/components/main-page/partners/mainPartners.module.css
+++ b/src/components/main-page/partners/mainPartners.module.css
@@ -1,5 +1,5 @@
 .mainPartners {
-  padding: scale(107px 0 179px 60px);
+  padding: scalesize(107px 0 179px 60px);
 
   @media screen and (max-width: $tablet-portrait) {
     padding: 56px 0 100px 24px;

--- a/src/components/main-page/platforms/main-platforms.module.css
+++ b/src/components/main-page/platforms/main-platforms.module.css
@@ -1,7 +1,7 @@
 .section {
   width: 100%;
   box-sizing: border-box;
-  padding: scale(65px 60px 105px 60px);
+  padding: scalesize(65px 60px 105px 60px);
   background-color: white;
   grid-area: platforms;
 }
@@ -10,45 +10,45 @@
   @mixin text;
   @mixin headline1;
 
-  margin-bottom: scale(74px);
+  margin-bottom: scalesize(74px);
 }
 
 .list {
   display: grid;
-  padding: scale(0);
-  margin: scale(0);
-  column-gap: scale(60px);
-  grid-template-columns: repeat(auto-fit, minmax(scale(300px), max-content));
+  padding: scalesize(0);
+  margin: scalesize(0);
+  column-gap: scalesize(60px);
+  grid-template-columns: repeat(auto-fit, minmax(scalesize(300px), max-content));
   list-style: none;
-  row-gap: scale(40px);
+  row-gap: scalesize(40px);
 }
 
 .item {
-  max-width: scale(300px);
-  min-height: scale(260px);
+  max-width: scalesize(300px);
+  min-height: scalesize(260px);
   box-sizing: border-box;
-  padding: scale(15px 30px 38px 30px);
-  border-bottom: scale(1px) solid var(--coal);
-  border-left: scale(1px) solid var(--coal);
+  padding: scalesize(15px 30px 38px 30px);
+  border-bottom: scalesize(1px) solid var(--coal);
+  border-left: scalesize(1px) solid var(--coal);
 }
 
 .mapIcon {
-  margin-bottom: scale(14px);
+  margin-bottom: scalesize(14px);
 }
 
 .title {
   @mixin headline;
   @mixin headline7;
 
-  margin-bottom: scale(15px);
+  margin-bottom: scalesize(15px);
 }
 
 .desc {
   @mixin text;
   @mixin textSmall;
 
-  margin-bottom: scale(12px);
-  margin-left: scale(30px);
+  margin-bottom: scalesize(12px);
+  margin-left: scalesize(30px);
 }
 
 .containerLink {
@@ -68,7 +68,7 @@
   @mixin text;
   @mixin textSmall;
 
-  margin-right: scale(8px);
+  margin-right: scalesize(8px);
 }
 
 .icon {
@@ -77,30 +77,30 @@
 
 @media {
   .section {
-    padding: scale(56px 55px 100px 55px);
+    padding: scalesize(56px 55px 100px 55px);
   }
 
   .titleMain {
     @mixin headline4;
 
-    margin-bottom: scale(40px);
+    margin-bottom: scalesize(40px);
   }
 
   .item {
     min-height: auto;
-    padding: scale(16px 25px 32px 25px);
+    padding: scalesize(16px 25px 32px 25px);
   }
 
   .title {
-    margin-bottom: scale(8px);
+    margin-bottom: scalesize(8px);
   }
 
   .desc {
-    margin-bottom: scale(32px);
-    margin-left: scale(16px);
+    margin-bottom: scalesize(32px);
+    margin-left: scalesize(16px);
   }
 
   .link {
-    margin-left: scale(16px);
+    margin-left: scalesize(16px);
   }
 }

--- a/src/components/main-page/title/main-title.module.css
+++ b/src/components/main-page/title/main-title.module.css
@@ -6,8 +6,8 @@
   grid-area: title;
 
   &&.primary {
-    max-width: scale(640px);
-    padding-left: scale(17px);
+    max-width: scalesize(640px);
+    padding-left: scalesize(17px);
     margin: auto;
 
     @media (max-width: 992px) {
@@ -22,7 +22,7 @@
   }
 
   &&.secondary {
-    padding: scale(0 81px 66px 477px);
+    padding: scalesize(0 81px 66px 477px);
 
     @media (max-width: $tablet-portrait) {
       padding: 0 85px 142px 24px;
@@ -51,7 +51,7 @@
   &&.secondary {
     @mixin headline1;
 
-    margin: scale(0 0 15px 0);
+    margin: scalesize(0 0 15px 0);
 
     @media (max-width: 1440px) {
       margin-bottom: 15px;
@@ -71,15 +71,15 @@
   display: inline-block;
 
   &&.primary {
-    width: scale(180px);
-    padding-bottom: scale(6px);
+    width: scalesize(180px);
+    padding-bottom: scalesize(6px);
 
     @media (max-width: 1290px) {
-      width: scale(200px);
+      width: scalesize(200px);
     }
 
     @media (max-width: 992px) {
-      width: scale(220px);
+      width: scalesize(220px);
     }
 
     @media (max-width: $tablet-portrait) {
@@ -88,7 +88,7 @@
   }
 
   &&.secondary {
-    width: scale(360px);
+    width: scalesize(360px);
     min-width: 244px;
 
     @media (max-width: $tablet-portrait) {
@@ -119,7 +119,7 @@
   display: inline;
   flex-direction: row;
   align-items: flex-end;
-  margin-bottom: scale(10px);
+  margin-bottom: scalesize(10px);
 
   @media (max-width: $tablet-portrait) {
     margin: 0;
@@ -127,9 +127,9 @@
 }
 
 .text {
-  width: scale(432px);
+  width: scalesize(432px);
   align-self: flex-end;
-  padding-right: scale(43px);
+  padding-right: scalesize(43px);
 
   @mixin text;
   @mixin textLarge;

--- a/src/components/navbar/actions/navbar-actions.module.css
+++ b/src/components/navbar/actions/navbar-actions.module.css
@@ -3,7 +3,7 @@
 
   @media (min-width: $tablet-portrait) {
     display: flex;
-    height: scale(61px);
+    height: scalesize(61px);
     flex-grow: 1;
     place-content: stretch;
   }

--- a/src/components/navbar/help-link/navbar-help-link.module.css
+++ b/src/components/navbar/help-link/navbar-help-link.module.css
@@ -10,12 +10,12 @@
 }
 
 .icon {
-  width: scale(25px);
-  height: scale(25px);
+  width: scalesize(25px);
+  height: scalesize(25px);
   fill: var(--coal);
 }
 
 .text {
-  font-size: scale(14px);
-  line-height: scale(17px);
+  font-size: scalesize(14px);
+  line-height: scalesize(17px);
 }

--- a/src/components/navbar/logotype/navbar-logotype.module.css
+++ b/src/components/navbar/logotype/navbar-logotype.module.css
@@ -4,6 +4,6 @@
   place-content: center;
 
   @media (min-width: $tablet-portrait) {
-    margin-right: scale(33px);
+    margin-right: scalesize(33px);
   }
 }

--- a/src/components/navbar/navbar.module.css
+++ b/src/components/navbar/navbar.module.css
@@ -6,6 +6,6 @@
   margin: 0 auto;
 
   @media (min-width: $tablet-portrait) {
-    padding: scale(0 0 0 20px);
+    padding: scalesize(0 0 0 20px);
   }
 }

--- a/src/components/navbar/section/navbar-section.module.css
+++ b/src/components/navbar/section/navbar-section.module.css
@@ -2,7 +2,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  padding: scale(0 24px);
+  padding: scalesize(0 24px);
 
   &:not(:last-child)::after {
     position: absolute;
@@ -22,6 +22,6 @@
   padding-right: 24px;
 
   @media (min-width: $tablet-portrait) {
-    padding-right: scale(24px);
+    padding-right: scalesize(24px);
   }
 }

--- a/src/components/overlay-nav/actions/overlay-nav-actions.module.css
+++ b/src/components/overlay-nav/actions/overlay-nav-actions.module.css
@@ -1,3 +1,3 @@
 .actions {
-  margin: scale(58px 0 0 54px);
+  margin: scalesize(58px 0 0 54px);
 }

--- a/src/components/overlay-nav/logotype/overlay-nav-logotype.module.css
+++ b/src/components/overlay-nav/logotype/overlay-nav-logotype.module.css
@@ -1,4 +1,4 @@
 .logotype {
   align-self: start;
-  margin: scale(48px 0 0 58px);
+  margin: scalesize(48px 0 0 58px);
 }

--- a/src/components/overlay-nav/menu/overlay-nav-menu.module.css
+++ b/src/components/overlay-nav/menu/overlay-nav-menu.module.css
@@ -1,3 +1,3 @@
 .menu {
-  margin: scale(32px 0 0 40px);
+  margin: scalesize(32px 0 0 40px);
 }

--- a/src/components/overlay-nav/socials/overlay-nav-socials.module.css
+++ b/src/components/overlay-nav/socials/overlay-nav-socials.module.css
@@ -1,3 +1,3 @@
 .socials {
-  margin: scale(70px 0 0);
+  margin: scalesize(70px 0 0);
 }

--- a/src/components/partners/partners.module.css
+++ b/src/components/partners/partners.module.css
@@ -6,11 +6,11 @@
   grid-area: partners;
   grid-template-columns: 100%;
   grid-template-rows: repeat(2, max-content);
-  row-gap: scale(69px);
+  row-gap: scalesize(69px);
 
   @media screen and (max-width: $tablet-portrait) {
     justify-items: center;
-    row-gap: scale(72px);
+    row-gap: scalesize(72px);
   }
 }
 
@@ -20,19 +20,19 @@
   align-items: center;
   padding: 0;
   margin: 0;
-  column-gap: scale(30px);
-  grid-auto-rows: minmax(scale(118px), scale(137px));
-  grid-template-columns: repeat(auto-fill, minmax(scale(182px), scale(210px)));
-  grid-template-rows: repeat(2, minmax(scale(118px), scale(137px)));
+  column-gap: scalesize(30px);
+  grid-auto-rows: minmax(scalesize(118px), scalesize(137px));
+  grid-template-columns: repeat(auto-fill, minmax(scalesize(182px), scalesize(210px)));
+  grid-template-rows: repeat(2, minmax(scalesize(118px), scalesize(137px)));
   justify-items: center;
   list-style-type: none;
-  row-gap: scale(15px);
+  row-gap: scalesize(15px);
 
   @media screen and (max-width: $tablet-portrait) {
     column-gap: 0;
-    grid-auto-rows: scale(118px);
-    grid-template-columns: repeat(2, scale(182px));
-    grid-template-rows: repeat(3, scale(118px));
+    grid-auto-rows: scalesize(118px);
+    grid-template-columns: repeat(2, scalesize(182px));
+    grid-template-rows: repeat(3, scalesize(118px));
     row-gap: 0;
   }
 
@@ -43,7 +43,7 @@
     box-sizing: border-box;
     align-items: center;
     justify-content: center;
-    padding: scale(25px 15px);
+    padding: scalesize(25px 15px);
   }
 }
 
@@ -52,7 +52,7 @@
 }
 
 .text {
-  padding: scale(15px 0 0 0);
+  padding: scalesize(15px 0 0 0);
 
   @mixin text;
   @mixin textPartners;
@@ -73,8 +73,8 @@
 
 .imageContainer {
   position: relative;
-  width: scale(182px);
-  height: scale(51px);
+  width: scalesize(182px);
+  height: scalesize(51px);
 
   @media screen and (max-width: $tablet-portrait) {
     width: 158px;

--- a/src/components/photos/photos.module.css
+++ b/src/components/photos/photos.module.css
@@ -5,7 +5,7 @@
   grid-template-columns: repeat(4, 1fr);
 
   @media screen and (max-width: $tablet-portrait) {
-    gap: scale(2px 3px);
+    gap: scalesize(2px 3px);
     grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/src/components/play-proposal-success/play-proposal-success.module.css
+++ b/src/components/play-proposal-success/play-proposal-success.module.css
@@ -1,14 +1,14 @@
 .container {
   display: grid;
   box-sizing: border-box;
-  padding-top: scale(123px);
-  gap: scale(51px);
+  padding-top: scalesize(123px);
+  gap: scalesize(51px);
 
   @media (max-width: $tablet-portrait) {
-    padding-top: scale(34px);
-    padding-bottom: scale(100px);
-    padding-left: scale(24px);
-    gap: scale(33px);
+    padding-top: scalesize(34px);
+    padding-bottom: scalesize(100px);
+    padding-left: scalesize(24px);
+    gap: scalesize(33px);
   }
 }
 
@@ -23,11 +23,11 @@
 
   &::after {
     position: absolute;
-    bottom: scale(100px);
-    left: scale(600px);
+    bottom: scalesize(100px);
+    left: scalesize(600px);
     display: block;
-    width: scale(152px);
-    height: scale(152px);
+    width: scalesize(152px);
+    height: scalesize(152px);
     box-sizing: border-box;
     border: 1px solid var(--coal);
     border-top: 0;
@@ -52,10 +52,10 @@
 }
 
 .image {
-  width: scale(930px);
+  width: scalesize(930px);
   height: 100%;
 
   @media (max-width: $tablet-portrait) {
-    width: scale(390px);
+    width: scalesize(390px);
   }
 }

--- a/src/components/project-cooperation/project-cooperation.module.css
+++ b/src/components/project-cooperation/project-cooperation.module.css
@@ -5,20 +5,20 @@
 
 .asterisk {
   display: flex;
-  width: scale(25px);
-  height: scale(25px);
+  width: scalesize(25px);
+  height: scalesize(25px);
 }
 
 .header {
   @mixin headline;
   @mixin headline5;
 
-  margin: scale(0 0 0 27px);
+  margin: scalesize(0 0 0 27px);
 
   @media (max-width: $tablet-portrait) {
     @mixin headline6;
 
-    margin: scale(0 0 0 30px);
+    margin: scalesize(0 0 0 30px);
   }
 }
 
@@ -26,17 +26,17 @@
   @mixin headline;
   @mixin headline7;
 
-  margin: scale(33px 0 0 85px);
+  margin: scalesize(33px 0 0 85px);
 
   @media (max-width: $tablet-portrait) {
-    margin: scale(16px 0 0 32px);
+    margin: scalesize(16px 0 0 32px);
   }
 
   &:last-of-type {
-    margin: scale(24px 0 0 85px);
+    margin: scalesize(24px 0 0 85px);
 
     @media (max-width: $tablet-portrait) {
-      margin: scale(24px 0 0 32px);
+      margin: scalesize(24px 0 0 32px);
     }
   }
 }

--- a/src/components/project-cooperation/project-cooperation.stories.module.css
+++ b/src/components/project-cooperation/project-cooperation.stories.module.css
@@ -1,9 +1,9 @@
 .storiesСontainer {
-  width: scale(553px);
-  margin: scale(92px auto 169px 665px);
+  width: scalesize(553px);
+  margin: scalesize(92px auto 169px 665px);
 
   @media (max-width: $tablet-portrait) {
-    width: scale(365px);
-    margin: scale(50px auto 100px 25px);
+    width: scalesize(365px);
+    margin: scalesize(50px auto 100px 25px);
   }
 }

--- a/src/components/project-description/project-description.module.css
+++ b/src/components/project-description/project-description.module.css
@@ -1,9 +1,9 @@
 .container {
-  padding: scale(79px 511px 120px 360px);
+  padding: scalesize(79px 511px 120px 360px);
   background-color: var(--light-green);
 
   @media (max-width: $tablet-portrait) {
-    padding: scale(55px 0 72px);
+    padding: scalesize(55px 0 72px);
   }
 }
 
@@ -11,10 +11,10 @@
   @mixin headline;
   @mixin headline4;
 
-  margin: scale(0 0 17px);
+  margin: scalesize(0 0 17px);
 
   @media (max-width: $tablet-portrait) {
-    margin: scale(0 24px 17px);
+    margin: scalesize(0 24px 17px);
   }
 }
 
@@ -22,11 +22,11 @@
   @mixin text;
   @mixin textLarge;
 
-  max-width: scale(509px);
+  max-width: scalesize(509px);
   margin: 0 0 0 auto;
 
   @media (max-width: $tablet-portrait) {
-    max-width: scale(304px);
-    margin: scale(0 24px 0 auto);
+    max-width: scalesize(304px);
+    margin: scalesize(0 24px 0 auto);
   }
 }

--- a/src/components/project-header/project-header.module.css
+++ b/src/components/project-header/project-header.module.css
@@ -1,7 +1,7 @@
 .container {
   display: grid;
   background-color: var(--beige);
-  gap: scale(0 120px);
+  gap: scalesize(0 120px);
   grid-template-areas:
     ". title"
     "intro image";
@@ -14,7 +14,7 @@
       "intro"
       "image";
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(2, min-content) scale(450px);
+    grid-template-rows: repeat(2, min-content) scalesize(450px);
   }
 }
 
@@ -22,13 +22,13 @@
   @mixin headline;
   @mixin headline1;
 
-  margin: scale(0 30px 63px 0);
+  margin: scalesize(0 30px 63px 0);
   grid-area: title;
 
   @media (max-width: $tablet-portrait) {
     @mixin headline4;
 
-    margin: scale(0 24px 22px);
+    margin: scalesize(0 24px 22px);
   }
 }
 
@@ -36,7 +36,7 @@
   @mixin headline;
   @mixin headline6;
 
-  max-width: scale(420px);
+  max-width: scalesize(420px);
   margin: 0 0 0 auto;
   font-weight: 300;
   grid-area: intro;
@@ -44,8 +44,8 @@
   @media (max-width: $tablet-portrait) {
     @mixin headline7;
 
-    max-width: scale(304px);
-    margin: scale(0 24px 36px auto);
+    max-width: scalesize(304px);
+    margin: scalesize(0 24px 36px auto);
   }
 }
 

--- a/src/components/section/section.module.css
+++ b/src/components/section/section.module.css
@@ -31,13 +31,13 @@
 
 .partners {
   .title {
-    max-width: scale(334px);
-    margin: scale(0 0 15px 0);
+    max-width: scalesize(334px);
+    margin: scalesize(0 0 15px 0);
 
     @mixin headline6;
 
     @media screen and (max-width: $tablet-portrait) {
-      margin-bottom: scale(24px);
+      margin-bottom: scalesize(24px);
     }
   }
 }

--- a/src/components/ui/basic-play-card/basic-play-card.module.css
+++ b/src/components/ui/basic-play-card/basic-play-card.module.css
@@ -15,7 +15,7 @@
   }
 
   @media (min-width: $desktop) {
-    min-height: scale(300px);
+    min-height: scalesize(300px);
   }
 }
 
@@ -31,7 +31,7 @@
   }
 
   @media (min-width: $desktop) {
-    height: scale(56px);
+    height: scalesize(56px);
   }
 }
 
@@ -57,7 +57,7 @@
   }
 
   @media (min-width: $desktop) {
-    margin: scale(16px 46px auto 16px);
+    margin: scalesize(16px 46px auto 16px);
   }
 }
 
@@ -72,7 +72,7 @@
   }
 
   @media (min-width: $desktop) {
-    margin: scale(16px 0 auto);
+    margin: scalesize(16px 0 auto);
   }
 }
 
@@ -82,7 +82,7 @@
   margin: 0;
 
   @media (min-width: $desktop) {
-    max-width: scale(190px);
+    max-width: scalesize(190px);
   }
 }
 
@@ -109,7 +109,7 @@
   }
 
   @media (min-width: $desktop) {
-    margin-top: scale(4px);
+    margin-top: scalesize(4px);
   }
 }
 

--- a/src/components/ui/burger-button/burger-button.module.css
+++ b/src/components/ui/burger-button/burger-button.module.css
@@ -1,7 +1,7 @@
 .button {
   position: relative;
-  width: scale(72px);
-  height: scale(72px);
+  width: scalesize(72px);
+  height: scalesize(72px);
   padding: 0;
   border: 0;
   margin: 0;
@@ -9,12 +9,12 @@
 
   &::before {
     position: absolute;
-    top: scale(28px);
+    top: scalesize(28px);
     left: 50%;
-    width: scale(20px);
-    height: scale(2px);
+    width: scalesize(20px);
+    height: scalesize(2px);
     background-color: var(--beige);
-    box-shadow: scale(0 6px 0 0) var(--beige), scale(0 12px 0 0) var(--beige);
+    box-shadow: scalesize(0 6px 0 0) var(--beige), scalesize(0 12px 0 0) var(--beige);
     content: "";
     transform: translateX(-50%);
   }
@@ -24,10 +24,10 @@
   &::before,
   &::after {
     position: absolute;
-    top: scale(35px);
+    top: scalesize(35px);
     left: 50%;
-    width: scale(24px);
-    height: scale(2px);
+    width: scalesize(24px);
+    height: scalesize(2px);
     background-color: var(--beige);
     box-shadow: none;
     content: "";

--- a/src/components/ui/form/action-caption/form-action-caption.module.css
+++ b/src/components/ui/form/action-caption/form-action-caption.module.css
@@ -2,7 +2,7 @@
   @mixin text;
   @mixin textCaption;
 
-  margin-top: scale(24px);
+  margin-top: scalesize(24px);
 
   a {
     color: inherit;
@@ -12,16 +12,16 @@
     white-space: pre-line;
 
     &:not(:first-child) {
-      margin: scale(17px 0 0);
+      margin: scalesize(17px 0 0);
     }
   }
 }
 
 .shift {
-  margin-left: scale(30px);
+  margin-left: scalesize(30px);
 }
 
 .below {
-  max-width: scale(340px);
-  margin-top: scale(16px);
+  max-width: scalesize(340px);
+  margin-top: scalesize(16px);
 }

--- a/src/components/ui/form/action/form-action.module.css
+++ b/src/components/ui/form/action/form-action.module.css
@@ -1,3 +1,3 @@
 .action {
-  margin-top: scale(24px);
+  margin-top: scalesize(24px);
 }

--- a/src/components/ui/form/actions/form-actions.module.css
+++ b/src/components/ui/form/actions/form-actions.module.css
@@ -1,3 +1,3 @@
 .actions {
-  margin-top: scale(12px);
+  margin-top: scalesize(12px);
 }

--- a/src/components/ui/form/field/form-field.module.css
+++ b/src/components/ui/form/field/form-field.module.css
@@ -1,5 +1,5 @@
 .field {
   &:not(:first-child) {
-    margin-top: scale(15px);
+    margin-top: scalesize(15px);
   }
 }

--- a/src/components/ui/form/fieldset/form-fieldset.module.css
+++ b/src/components/ui/form/fieldset/form-fieldset.module.css
@@ -4,10 +4,10 @@
   margin: 0;
 
   &:not(:first-of-type) {
-    margin-top: scale(72px);
+    margin-top: scalesize(72px);
 
     @media (max-width: $tablet-portrait) {
-      margin-top: scale(90px);
+      margin-top: scalesize(90px);
     }
   }
 }
@@ -24,8 +24,8 @@
 }
 
 .container {
-  margin-top: scale(15px);
-  margin-left: scale(61px);
+  margin-top: scalesize(15px);
+  margin-left: scalesize(61px);
 
   @media (max-width: $tablet-portrait) {
     margin-left: 0;

--- a/src/components/ui/menu/type/footer-navigation.module.css
+++ b/src/components/ui/menu/type/footer-navigation.module.css
@@ -2,10 +2,10 @@
   padding: 0;
   margin: 0;
   column-count: 2;
-  column-gap: scale(56px);
+  column-gap: scalesize(56px);
 
   @media (max-width: $tablet-portrait) {
-    column-gap: scale(16px);
+    column-gap: scalesize(16px);
   }
 }
 
@@ -13,10 +13,10 @@
   display: block;
 
   &:not(:first-child) {
-    margin-top: scale(15px);
+    margin-top: scalesize(15px);
 
     @media (max-width: $tablet-portrait) {
-      margin-top: scale(13px);
+      margin-top: scalesize(13px);
     }
   }
 }

--- a/src/components/ui/menu/type/footer-project-list.module.css
+++ b/src/components/ui/menu/type/footer-project-list.module.css
@@ -7,10 +7,10 @@
   display: block;
 
   &:not(:first-child) {
-    margin-top: scale(15px);
+    margin-top: scalesize(15px);
 
     @media (max-width: $tablet-portrait) {
-      margin-top: scale(13px);
+      margin-top: scalesize(13px);
     }
   }
 }

--- a/src/components/ui/menu/type/general-submenu.module.css
+++ b/src/components/ui/menu/type/general-submenu.module.css
@@ -1,18 +1,18 @@
 .menu {
   display: flex;
   overflow: auto;
-  padding: scale(0);
-  margin: scale(0);
+  padding: scalesize(0);
+  margin: scalesize(0);
   scroll-behavior: smooth;
 
   &::-webkit-scrollbar {
-    width: scale(0);
+    width: scalesize(0);
   }
 }
 
 .item {
   display: block;
-  margin-right: scale(24px);
+  margin-right: scalesize(24px);
 }
 
 .link {
@@ -30,24 +30,24 @@
     width: .6em;
     height: 1.6em;
     box-sizing: border-box;
-    border: scale(1px) solid currentColor;
+    border: scalesize(1px) solid currentColor;
     content: '';
     visibility: hidden;
 
     @media (min-width: $desktop) {
-      width: scale(10px);
-      height: scale(24px);
+      width: scalesize(10px);
+      height: scalesize(24px);
     }
   }
 
   &::before {
-    border-right: scale(0);
+    border-right: scalesize(0);
     border-bottom-left-radius: 200% 100%;
     border-top-left-radius: 200% 100%;
   }
 
   &::after {
-    border-left: scale(0);
+    border-left: scalesize(0);
     border-bottom-right-radius: 200% 100%;
     border-top-right-radius: 200% 100%;
   }

--- a/src/components/ui/menu/type/main-navigation.module.css
+++ b/src/components/ui/menu/type/main-navigation.module.css
@@ -8,7 +8,7 @@
   display: block;
 
   &:not(:last-child) {
-    margin-right: scale(24px);
+    margin-right: scalesize(24px);
   }
 }
 
@@ -17,8 +17,8 @@
 
   display: flex;
   align-items: flex-start;
-  font-size: scale(16px);
-  line-height: scale(22px);
+  font-size: scalesize(16px);
+  line-height: scalesize(22px);
   text-decoration: none;
   white-space: nowrap;
 
@@ -28,7 +28,7 @@
     width: .6em;
     height: 1.6em;
     box-sizing: border-box;
-    border: scale(1px) solid currentColor;
+    border: scalesize(1px) solid currentColor;
     content: '';
     visibility: hidden;
   }

--- a/src/components/ui/menu/type/overlay-actions.module.css
+++ b/src/components/ui/menu/type/overlay-actions.module.css
@@ -28,7 +28,7 @@
 
   position: relative;
   display: flex;
-  padding: scale(15px);
+  padding: scalesize(15px);
   color: inherit;
   cursor: pointer;
   line-height: 1.6;

--- a/src/components/ui/menu/type/overlay-navigation.module.css
+++ b/src/components/ui/menu/type/overlay-navigation.module.css
@@ -15,7 +15,7 @@
 
   display: inline-flex;
   align-items: center;
-  padding: scale(6px 0);
+  padding: scalesize(6px 0);
   color: var(--coal);
   text-decoration: none;
   white-space: nowrap;

--- a/src/components/ui/menu/type/overlay-social-links.module.css
+++ b/src/components/ui/menu/type/overlay-social-links.module.css
@@ -17,7 +17,7 @@
   @mixin textSmall;
 
   display: flex;
-  padding: scale(15px);
+  padding: scalesize(15px);
   background-color: var(--beige);
   color: var(--coal);
   place-content: center space-between;

--- a/src/components/ui/menu/type/social-links.module.css
+++ b/src/components/ui/menu/type/social-links.module.css
@@ -8,7 +8,7 @@
   display: block;
 
   &:not(:last-child) {
-    margin-right: scale(16px);
+    margin-right: scalesize(16px);
   }
 }
 
@@ -17,8 +17,8 @@
 
   display: block;
   color: var(--coal);
-  font-size: scale(16px);
-  line-height: scale(18px);
+  font-size: scalesize(16px);
+  line-height: scalesize(18px);
   text-decoration: none;
   white-space: nowrap;
 }

--- a/src/components/ui/person-card/person-card.module.css
+++ b/src/components/ui/person-card/person-card.module.css
@@ -4,44 +4,44 @@
 }
 
 .containerVolunteer {
-  width: scale(180px);
+  width: scalesize(180px);
 
   @media (max-width: $tablet-portrait) {
-    width: scale(213px);
+    width: scalesize(213px);
   }
 }
 
 .containerParticipant {
-  width: scale(210px);
+  width: scalesize(210px);
 
   @media (max-width: $tablet-portrait) {
-    width: scale(213px);
+    width: scalesize(213px);
   }
 }
 
 .imgVolunteer {
   width: 100%;
-  height: scale(228px);
+  height: scalesize(228px);
   object-fit: cover;
 
   @media (max-width: $tablet-portrait) {
-    height: scale(265px);
+    height: scalesize(265px);
   }
 }
 
 .imgParticipant {
   width: 100%;
-  height: scale(265px);
+  height: scalesize(265px);
   object-fit: cover;
 }
 
 .comment {
   position: absolute;
-  top: scale(170px);
-  left: scale(14px);
+  top: scalesize(170px);
+  left: scalesize(14px);
   display: flex;
-  width: scale(45px);
-  height: scale(45px);
+  width: scalesize(45px);
+  height: scalesize(45px);
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -53,8 +53,8 @@
   transition: width 400ms cubic-bezier(.6, 0, .5, 1), height 400ms cubic-bezier(.6, 0, .5, 1), top 400ms cubic-bezier(.6, 0, .5, 1), left 400ms cubic-bezier(.6, 0, .5, 1);
 
   @media (max-width: $tablet-portrait) {
-    top: scale(208px);
-    left: scale(16px);
+    top: scalesize(208px);
+    left: scalesize(16px);
   }
 }
 
@@ -63,14 +63,14 @@
 }
 
 .comment:hover {
-  top: scale(165px);
-  left: scale(9px);
-  width: scale(55px);
-  height: scale(55px);
+  top: scalesize(165px);
+  left: scalesize(9px);
+  width: scalesize(55px);
+  height: scalesize(55px);
 
   @media (max-width: $tablet-portrait) {
-    top: scale(203px);
-    left: scale(11px);
+    top: scalesize(203px);
+    left: scalesize(11px);
   }
 }
 
@@ -79,7 +79,7 @@
 
   display: -webkit-box;
   overflow: hidden;
-  margin-top: scale(16px);
+  margin-top: scalesize(16px);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow-wrap: break-word;
@@ -104,8 +104,8 @@
 
   display: -webkit-box;
   overflow: hidden;
-  margin-top: scale(8px);
-  margin-left: scale(33px);
+  margin-top: scalesize(8px);
+  margin-left: scalesize(33px);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
   overflow-wrap: break-word;

--- a/src/components/ui/text-area/text-area.module.css
+++ b/src/components/ui/text-area/text-area.module.css
@@ -5,7 +5,7 @@
   display: block;
   width: 100%;
   height: auto;
-  padding: scale(8px 0);
+  padding: scalesize(8px 0);
   border: 0;
   border-bottom: 1px solid var(--coal);
   background-color: transparent;
@@ -26,6 +26,6 @@
   @mixin textCaption;
 
   display: inline-block;
-  margin-top: scale(3px);
+  margin-top: scalesize(3px);
   color: var(--red);
 }

--- a/src/components/ui/text-input/text-input.module.css
+++ b/src/components/ui/text-input/text-input.module.css
@@ -4,7 +4,7 @@
 
   display: block;
   width: 100%;
-  padding: scale(8px 0);
+  padding: scalesize(8px 0);
   border: 0;
   border-bottom: 1px solid var(--coal);
   background-color: transparent;
@@ -25,6 +25,6 @@
   @mixin textCaption;
 
   display: inline-block;
-  margin-top: scale(3px);
+  margin-top: scalesize(3px);
   color: var(--red);
 }

--- a/src/components/what-we-do-authors/what-we-do-authors.module.css
+++ b/src/components/what-we-do-authors/what-we-do-authors.module.css
@@ -2,28 +2,28 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: scale(86px 24px 0);
+  padding: scalesize(86px 24px 0);
 }
 
 .title {
   @mixin headline;
   @mixin headline5;
 
-  max-width: scale(600px);
-  margin: scale(0 120px 82px) auto;
+  max-width: scalesize(600px);
+  margin: scalesize(0 120px 82px) auto;
 }
 
 .list {
   display: grid;
   width: 100%;
   justify-content: center;
-  padding: scale(0);
-  margin: scale(0);
-  margin-bottom: scale(150px);
-  column-gap: scale(62px);
+  padding: scalesize(0);
+  margin: scalesize(0);
+  margin-bottom: scalesize(150px);
+  column-gap: scalesize(62px);
   grid-template-columns: repeat(auto-fill, minmax(15rem, max-content));
   list-style: none;
-  row-gap: scale(6px);
+  row-gap: scalesize(6px);
 }
 
 .item {
@@ -35,17 +35,17 @@
 
 @media (max-width: $tablet-portrait) {
   .authors {
-    padding-top: scale(56px);
+    padding-top: scalesize(56px);
   }
 
   .title {
     @mixin headline6;
 
-    margin: scale(0);
-    margin-bottom: scale(40px);
+    margin: scalesize(0);
+    margin-bottom: scalesize(40px);
   }
 
   .list {
-    margin-bottom: scale(72px);
+    margin-bottom: scalesize(72px);
   }
 }

--- a/src/components/what-we-do-contacts/what-we-do-contacts.module.css
+++ b/src/components/what-we-do-contacts/what-we-do-contacts.module.css
@@ -1,5 +1,5 @@
 .contacts {
-  padding: scale(72px 170px 164px 150px);
+  padding: scalesize(72px 170px 164px 150px);
   color: var(--white);
 }
 
@@ -7,8 +7,8 @@
   @mixin headline;
   @mixin headline5;
 
-  max-width: scale(485px);
-  margin-bottom: scale(36px);
+  max-width: scalesize(485px);
+  margin-bottom: scalesize(36px);
 }
 
 .desc {
@@ -16,26 +16,26 @@
   @mixin headline6;
 
   display: flex;
-  max-width: scale(610px);
+  max-width: scalesize(610px);
   align-items: baseline;
   margin-left: auto;
 }
 
 .asterisk {
   display: block;
-  margin: scale(0);
-  margin-bottom: scale(14px);
+  margin: scalesize(0);
+  margin-bottom: scalesize(14px);
 }
 
 @media all and (max-width: $tablet-portrait) {
   .contacts {
-    padding: scale(56px 24px 50px);
+    padding: scalesize(56px 24px 50px);
   }
 
   .title {
     @mixin headline6;
 
-    margin-bottom: scale(28px);
+    margin-bottom: scalesize(28px);
   }
 
   .desc {

--- a/src/components/what-we-do-desc/what-we-do-desc.module.css
+++ b/src/components/what-we-do-desc/what-we-do-desc.module.css
@@ -1,37 +1,37 @@
 .descItem {
-  padding: scale(92px 24px 170px 0);
+  padding: scalesize(92px 24px 170px 0);
   background-color: #ecebe8;
   color: var(--beige);
 }
 
 .content {
   display: grid;
-  column-gap: scale(90px);
-  grid-template-columns: repeat(auto-fit, minmax(scale(440px), max-content));
+  column-gap: scalesize(90px);
+  grid-template-columns: repeat(auto-fit, minmax(scalesize(440px), max-content));
   row-gap: 24px;
 }
 
 .contentReception {
-  margin-bottom: scale(190px);
-  margin-left: scale(120px);
+  margin-bottom: scalesize(190px);
+  margin-left: scalesize(120px);
 }
 
 .container {
-  max-width: scale(600px);
+  max-width: scalesize(600px);
 }
 
 .mainTitle {
   @mixin headline;
   @mixin headline3;
 
-  margin-bottom: scale(76px);
+  margin-bottom: scalesize(76px);
 }
 
 .title {
   @mixin headline;
   @mixin headline5;
 
-  margin-bottom: scale(24px);
+  margin-bottom: scalesize(24px);
 }
 
 .desc {
@@ -40,53 +40,53 @@
 }
 
 .contentSelected {
-  margin-bottom: scale(140px);
+  margin-bottom: scalesize(140px);
 }
 
 .containerSelected {
-  margin-top: scale(20px);
+  margin-top: scalesize(20px);
 }
 
 .imgSelected {
   @mixin img;
 
-  max-width: scale(630px);
+  max-width: scalesize(630px);
 }
 
 .containerInvite {
-  margin-left: scale(210px);
+  margin-left: scalesize(210px);
 }
 
 .imgReception {
   @mixin img;
 
-  max-width: scale(450px);
-  margin-top: scale(14px);
+  max-width: scalesize(450px);
+  margin-top: scalesize(14px);
 }
 
 @media (max-width: $tablet-portrait) {
   .descItem {
-    padding: scale(56px 24px 72px 0);
+    padding: scalesize(56px 24px 72px 0);
   }
 
   .contentReception {
-    margin-bottom: scale(0);
-    margin-left: scale(24px);
+    margin-bottom: scalesize(0);
+    margin-left: scalesize(24px);
   }
 
   .contentSelected {
-    margin-bottom: scale(0);
+    margin-bottom: scalesize(0);
   }
 
   .content {
-    margin-bottom: scale(72px);
-    grid-template-columns: repeat(auto-fit, minmax(scale(274px), max-content));
+    margin-bottom: scalesize(72px);
+    grid-template-columns: repeat(auto-fit, minmax(scalesize(274px), max-content));
   }
 
   .mainTitle {
     @mixin headline4;
 
-    margin-bottom: scale(24px);
+    margin-bottom: scalesize(24px);
   }
 
   .title {
@@ -94,7 +94,7 @@
   }
 
   .titleWidth {
-    max-width: scale(330px);
+    max-width: scalesize(330px);
   }
 
   .desc {
@@ -102,8 +102,8 @@
   }
 
   .imgReception {
-    max-width: scale(274px);
-    margin-top: scale(0);
+    max-width: scalesize(274px);
+    margin-top: scalesize(0);
     margin-left: auto;
   }
 
@@ -112,11 +112,11 @@
   }
 
   .containerSelected {
-    margin-left: scale(24px);
+    margin-left: scalesize(24px);
     grid-row-start: 1;
   }
 
   .containerInvite {
-    margin-left: scale(24px);
+    margin-left: scalesize(24px);
   }
 }

--- a/src/components/what-we-do-header/what-we-do-header.module.css
+++ b/src/components/what-we-do-header/what-we-do-header.module.css
@@ -10,35 +10,35 @@
 }
 
 .menu {
-  margin: scale(40px 0 70px 70px);
+  margin: scalesize(40px 0 70px 70px);
 }
 
 .title {
   @mixin headline;
   @mixin headline2;
 
-  max-width: scale(924px);
-  margin-bottom: scale(53px);
-  margin-left: scale(62px);
+  max-width: scalesize(924px);
+  margin-bottom: scalesize(53px);
+  margin-left: scalesize(62px);
 }
 
 .containerText {
   display: flex;
-  max-width: scale(520px);
+  max-width: scalesize(520px);
   flex-direction: column;
   align-self: end;
-  margin: scale(0 110px 15px 85px);
+  margin: scalesize(0 110px 15px 85px);
 }
 
 .desc {
   @mixin headline;
   @mixin textLarge;
 
-  margin-bottom: scale(20px);
-  line-height: scale(1.5rem);
+  margin-bottom: scalesize(20px);
+  line-height: scalesize(1.5rem);
 
   &:last-of-type {
-    margin: scale(0);
+    margin: scalesize(0);
   }
 }
 
@@ -50,8 +50,8 @@
 .img {
   @mixin img;
 
-  width: calc(100% - scale(24px));
-  max-width: scale(720px);
+  width: calc(100% - scalesize(24px));
+  max-width: scalesize(720px);
 }
 
 .containerSpace {
@@ -60,30 +60,30 @@
 
 .containerSpaceUp {
   width: 100%;
-  min-width: scale(24px);
+  min-width: scalesize(24px);
   height: 47%;
   background-color: var(--light-green);
 }
 
 .containerSpaceDown {
   width: 100%;
-  min-width: scale(24px);
+  min-width: scalesize(24px);
   height: 53%;
   background-color: var(--beige);
 }
 
 @media (max-width: $tablet-portrait) {
   .menu {
-    margin: scale(26px 0 32px 24px);
+    margin: scalesize(26px 0 32px 24px);
   }
 
   .title {
     @mixin headline4;
 
-    margin: scale(0 24px 30px 24px);
+    margin: scalesize(0 24px 30px 24px);
   }
 
   .containerText {
-    margin: scale(0 24px 72px 85px);
+    margin: scalesize(0 24px 72px 85px);
   }
 }

--- a/src/components/what-we-do-partners/what-we-do-partners.module.css
+++ b/src/components/what-we-do-partners/what-we-do-partners.module.css
@@ -3,9 +3,9 @@
 }
 
 .partners {
-  padding: scale(70px 210px 138px 210px);
+  padding: scalesize(70px 210px 138px 210px);
 
   @media (max-width: $tablet-portrait) {
-    padding: scale(80px 24px 100px 24px);
+    padding: scalesize(80px 24px 100px 24px);
   }
 }

--- a/src/components/what-we-do-selection/what-we-do-selection.module.css
+++ b/src/components/what-we-do-selection/what-we-do-selection.module.css
@@ -1,5 +1,5 @@
 .selection {
-  padding: scale(54px 60px 45px);
+  padding: scalesize(54px 60px 45px);
   background-color: var(--beige);
 }
 
@@ -7,26 +7,26 @@
   @mixin headline;
   @mixin headline3;
 
-  max-width: scale(540px);
-  margin: scale(0 180px 56px) auto;
+  max-width: scalesize(540px);
+  margin: scalesize(0 180px 56px) auto;
 }
 
 .list {
   display: grid;
   justify-content: center;
-  padding: scale(0);
-  margin: scale(0);
-  margin-bottom: scale(68px);
-  column-gap: scale(90px);
+  padding: scalesize(0);
+  margin: scalesize(0);
+  margin-bottom: scalesize(68px);
+  column-gap: scalesize(90px);
   grid-template-columns: repeat(auto-fit, minmax(21.875rem, max-content));
   list-style: none;
-  row-gap: scale(64px);
+  row-gap: scalesize(64px);
 }
 
 .item {
   display: grid;
   align-content: start;
-  row-gap: scale(24px);
+  row-gap: scalesize(24px);
 }
 
 .number {
@@ -38,7 +38,7 @@
   @mixin headline;
   @mixin headline6;
 
-  min-height: scale(96px);
+  min-height: scalesize(96px);
 }
 
 .desc {
@@ -48,13 +48,13 @@
 
 .poster {
   display: grid;
-  max-width: scale(1320px);
+  max-width: scalesize(1320px);
   justify-content: space-evenly;
-  padding: scale(0 24px 64px);
-  margin: scale(0) auto;
+  padding: scalesize(0 24px 64px);
+  margin: scalesize(0) auto;
   background-color: var(--light-green);
-  column-gap: scale(20px);
-  grid-template-columns: repeat(auto-fit, minmax(scale(305px), max-content));
+  column-gap: scalesize(20px);
+  grid-template-columns: repeat(auto-fit, minmax(scalesize(305px), max-content));
 }
 
 .posterTitle {
@@ -62,48 +62,48 @@
   @mixin headline6;
 
   display: flex;
-  max-width: scale(468px);
+  max-width: scalesize(468px);
   flex-direction: column;
-  margin-top: scale(64px);
+  margin-top: scalesize(64px);
 }
 
 .ampersand {
   @mixin headline;
   @mixin headline1;
 
-  margin-bottom: scale(16px);
+  margin-bottom: scalesize(16px);
 }
 
 .posterDesc {
   @mixin text;
   @mixin textSmall;
 
-  max-width: scale(485px);
-  margin-top: scale(220px);
+  max-width: scalesize(485px);
+  margin-top: scalesize(220px);
   margin-left: auto;
 }
 
 @media (max-width: $tablet-portrait) {
   .selection {
-    padding: scale(40px 0 0);
+    padding: scalesize(40px 0 0);
   }
 
   .mainTitle {
     @mixin headline4;
 
-    padding: scale(0 24px);
-    margin: scale(0);
-    margin-bottom: scale(24px);
+    padding: scalesize(0 24px);
+    margin: scalesize(0);
+    margin-bottom: scalesize(24px);
   }
 
   .list {
-    padding: scale(0 24px);
-    margin-bottom: scale(72px);
+    padding: scalesize(0 24px);
+    margin-bottom: scalesize(72px);
     grid-template-columns: none;
   }
 
   .item {
-    row-gap: scale(0);
+    row-gap: scalesize(0);
   }
 
   .number {
@@ -111,28 +111,28 @@
   }
 
   .title {
-    min-height: scale(0);
-    margin-bottom: scale(24px);
+    min-height: scalesize(0);
+    margin-bottom: scalesize(24px);
   }
 
   .desc {
-    max-width: scale(280px);
+    max-width: scalesize(280px);
     align-self: right;
-    margin-right: scale(24px);
-    margin-bottom: scale(24px);
+    margin-right: scalesize(24px);
+    margin-bottom: scalesize(24px);
     margin-left: auto;
 
     &:last-of-type {
-      margin-bottom: scale(0);
+      margin-bottom: scalesize(0);
     }
   }
 
   .poster {
-    padding-bottom: scale(72px);
+    padding-bottom: scalesize(72px);
   }
 
   .posterDesc {
-    max-width: scale(305px);
-    margin-top: scale(24px);
+    max-width: scalesize(305px);
+    margin-top: scalesize(24px);
   }
 }

--- a/src/shared/helpers/scaleSize.js
+++ b/src/shared/helpers/scaleSize.js
@@ -2,11 +2,11 @@ const defaults = {
   customProperty: '--scale'
 };
 
-const scale = (options) => (values) => {
+const scaleSize = (options) => (values) => {
   const { customProperty } = { ...defaults, ...options };
 
   return values.replace(/(\d*\.?\d+)px/gi, `calc(var(${customProperty}) * $1)`);
 };
 
 // eslint-disable-next-line no-undef
-module.exports = scale;
+module.exports = scaleSize;

--- a/src/shared/styles/mixins/headline.css
+++ b/src/shared/styles/mixins/headline.css
@@ -8,36 +8,36 @@
 }
 
 @define-mixin headline1 {
-  font-size: scale(72px);
-  line-height: scale(70px);
+  font-size: scalesize(72px);
+  line-height: scalesize(70px);
 }
 
 @define-mixin headline2 {
-  font-size: scale(64px);
-  line-height: scale(60px);
+  font-size: scalesize(64px);
+  line-height: scalesize(60px);
 }
 
 @define-mixin headline3 {
-  font-size: scale(56px);
-  line-height: scale(56px);
+  font-size: scalesize(56px);
+  line-height: scalesize(56px);
 }
 
 @define-mixin headline4 {
-  font-size: scale(40px);
-  line-height: scale(40px);
+  font-size: scalesize(40px);
+  line-height: scalesize(40px);
 }
 
 @define-mixin headline5 {
-  font-size: scale(36px);
-  line-height: scale(38px);
+  font-size: scalesize(36px);
+  line-height: scalesize(38px);
 }
 
 @define-mixin headline6 {
-  font-size: scale(28px);
-  line-height: scale(32px);
+  font-size: scalesize(28px);
+  line-height: scalesize(32px);
 }
 
 @define-mixin headline7 {
-  font-size: scale(20px);
-  line-height: scale(24px);
+  font-size: scalesize(20px);
+  line-height: scalesize(24px);
 }

--- a/src/shared/styles/mixins/text.css
+++ b/src/shared/styles/mixins/text.css
@@ -13,18 +13,18 @@
 }
 
 @define-mixin textMedium {
-  font-size: scale(18px);
-  line-height: scale(23px);
+  font-size: scalesize(18px);
+  line-height: scalesize(23px);
 }
 
 @define-mixin textSmall {
-  font-size: scale(16px);
-  line-height: scale(22px);
+  font-size: scalesize(16px);
+  line-height: scalesize(22px);
 }
 
 @define-mixin textCaption {
-  font-size: scale(14px);
-  line-height: scale(17px);
+  font-size: scalesize(14px);
+  line-height: scalesize(17px);
 }
 
 @define-mixin textButton {
@@ -32,8 +32,8 @@
 }
 
 @define-mixin textSmallButton {
-  font-size: scale(16px);
-  line-height: scale(14px);
+  font-size: scalesize(16px);
+  line-height: scalesize(14px);
 }
 
 @define-mixin textLargeButton {
@@ -41,11 +41,11 @@
 }
 
 @define-mixin textPartners {
-  font-size: scale(14px);
-  line-height: scale(20px);
+  font-size: scalesize(14px);
+  line-height: scalesize(20px);
 }
 
 @define-mixin textHistorySmall {
-  font-size: scale(16px);
-  line-height: scale(24px);
+  font-size: scalesize(16px);
+  line-height: scalesize(24px);
 }

--- a/src/shared/styles/vars.css
+++ b/src/shared/styles/vars.css
@@ -2,7 +2,7 @@
   --page-content-max-width: 1440px;
   --page-content-min-width: 414px;
 
-  /* Коэффициент для масштабирования размеров с помощью хелпера scale() */
+  /* Коэффициент для масштабирования размеров с помощью хелпера scaleSize() */
   --scale: calc(100vw / 414);
 
   @media (min-width: $tablet-portrait) {


### PR DESCRIPTION
## Описание
В карточках блога, проекта и некоторых элементах слайдера используется `transform: scale(1.2)`. Из-за кастомного scale(), который мы используем для ресайза размеров, нативный функционал перестал работать. Переименование кастомного scale в scaleSize решает эту проблему.

## Ссылка на задачу
[Rename scale](https://www.notion.so/Front-52aae4efcc1743f58f4abf64bf7357ff?p=97ae198310774d09b593a468e71bb25a)
