### PR TITLE
fix: ugly hack to make fetcher work on Vercel

### DIFF
--- a/src/shared/fetcher.ts
+++ b/src/shared/fetcher.ts
@@ -3,9 +3,13 @@ import { addOriginToApiPath } from 'shared/helpers/url';
 export const fetcher = async <T = unknown>(path: string, options?: RequestInit): Promise<T>  => {
   let fetchImplementation = fetch;
 
-  if (process.env.NODE_ENV === 'development') {
-    fetchImplementation = (await import('mocks/fetch-mock')).default;
-  }
+  // TODO: Вернуть как было!
+  // if (process.env.NODE_ENV === 'development') {
+  //   fetchImplementation = (await import('mocks/fetch-mock')).default;
+  // }
+
+  // TODO: Временный хардкод для Vercel
+  fetchImplementation = (await import('mocks/fetch-mock')).default;
 
   const response = await fetchImplementation(addOriginToApiPath(path), options);
 


### PR DESCRIPTION
## Описание
Vercel переписывает `NODE_ENV` переменную, если я пытаюсь сказать что нужно быть `development`

Как временное решение - можно использовать моки вообще всегда, но надо не забыть вернуть как было, когда будут ендпоинты.
