### PR TITLE
basic-play-card: рендеринг нескольких авторов

### DIFF
--- a/src/components/ui/basic-play-card/basic-play-card.module.css
+++ b/src/components/ui/basic-play-card/basic-play-card.module.css
@@ -65,7 +65,10 @@
 .author {
   display: inline;
   max-width: scale(190px);
-  margin: 0;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 .authorMultiple {

--- a/src/components/ui/basic-play-card/basic-play-card.module.css
+++ b/src/components/ui/basic-play-card/basic-play-card.module.css
@@ -5,12 +5,14 @@
 
 .container {
   display: flex;
+  width: scale(240px);
   min-height: scale(300px);
   flex-direction: column;
   justify-content: space-between;
   background-color: var(--light-green);
 
   @media (max-width: $tablet-portrait) {
+    width: scale(244px);
     min-height: scale(341px);
   }
 }
@@ -64,6 +66,10 @@
   display: inline;
   max-width: scale(190px);
   margin: 0;
+}
+
+.authorMultiple {
+  max-width: scale(238px);
 }
 
 .authorName {

--- a/src/components/ui/basic-play-card/basic-play-card.stories.tsx
+++ b/src/components/ui/basic-play-card/basic-play-card.stories.tsx
@@ -6,14 +6,6 @@ import { BasicPlayCard } from './basic-play-card';
 export default {
   title: 'UI/BasicPlayCard',
   component: BasicPlayCard,
-  decorators: [
-    (Story) => (
-      <div style={{ width: '240px'}}>
-        <Story/>
-      </div>
-    ),
-  ],
-
 } as ComponentMeta<typeof BasicPlayCard>;
 
 const Template: ComponentStory<typeof BasicPlayCard> = (args) => <BasicPlayCard {...args} />;
@@ -27,7 +19,7 @@ Default.args = {
     linkView: 'https://lubimovka.ru/',
     linkDownload: 'https://lubimovka.ru/',
   },
-  authors: [{
+  author: [{
     id: 1,
     name: 'Екатерина Августеняк',
   }],
@@ -43,7 +35,7 @@ PlayCardWithMultipleAuthors.args = {
     linkView: 'https://lubimovka.ru/',
     linkDownload: 'https://lubimovka.ru/',
   },
-  authors: [
+  author: [
     {
       id: 1,
       name: 'Екатерина Августеняк',
@@ -69,7 +61,7 @@ PlayCardWithVisibleButtons.args = {
     linkView: 'https://lubimovka.ru/',
     linkDownload: 'https://lubimovka.ru/',
   },
-  authors: [{
+  author: [{
     id: 1,
     name: 'Екатерина Августеняк',
   }],

--- a/src/components/ui/basic-play-card/basic-play-card.stories.tsx
+++ b/src/components/ui/basic-play-card/basic-play-card.stories.tsx
@@ -27,10 +27,36 @@ Default.args = {
     linkView: 'https://lubimovka.ru/',
     linkDownload: 'https://lubimovka.ru/',
   },
-  author: {
+  authors: [{
     id: 1,
     name: 'Екатерина Августеняк',
+  }],
+  buttonVisibility: false,
+};
+
+export const PlayCardWithMultipleAuthors = Template.bind({});
+PlayCardWithMultipleAuthors.args = {
+  play: {
+    title: 'Конкретные разговоры пожилых супругов ни о чём',
+    city: 'Санкт-Петербург',
+    year: '2020',
+    linkView: 'https://lubimovka.ru/',
+    linkDownload: 'https://lubimovka.ru/',
   },
+  authors: [
+    {
+      id: 1,
+      name: 'Екатерина Августеняк',
+    },
+    {
+      id: 2,
+      name: 'Антон Чехов',
+    },
+    {
+      id: 3,
+      name: 'Василий Косотрясов',
+    },
+  ],
   buttonVisibility: false,
 };
 
@@ -43,9 +69,9 @@ PlayCardWithVisibleButtons.args = {
     linkView: 'https://lubimovka.ru/',
     linkDownload: 'https://lubimovka.ru/',
   },
-  author: {
+  authors: [{
     id: 1,
     name: 'Екатерина Августеняк',
-  },
+  }],
   buttonVisibility: true,
 };

--- a/src/components/ui/basic-play-card/basic-play-card.stories.tsx
+++ b/src/components/ui/basic-play-card/basic-play-card.stories.tsx
@@ -13,57 +13,60 @@ const Template: ComponentStory<typeof BasicPlayCard> = (args) => <BasicPlayCard 
 export const Default = Template.bind({});
 Default.args = {
   play: {
-    title: 'Конкретные разговоры пожилых супругов ни о чём',
-    city: 'Санкт-Петербург',
-    year: '2020',
-    linkView: 'https://lubimovka.ru/',
-    linkDownload: 'https://lubimovka.ru/',
-  },
-  author: [{
     id: 1,
-    name: 'Екатерина Августеняк',
-  }],
+    name: 'Конкретные разговоры пожилых супругов ни о чём',
+    city: 'Санкт-Петербург',
+    year: 2020,
+    url_reading: 'https://lubimovka.ru/',
+    url_download: 'https://lubimovka.ru/',
+    authors: [{
+      id: 1,
+      name: 'Екатерина Августеняк',
+    }],
+  },
   buttonVisibility: false,
 };
 
 export const PlayCardWithMultipleAuthors = Template.bind({});
 PlayCardWithMultipleAuthors.args = {
   play: {
-    title: 'Конкретные разговоры пожилых супругов ни о чём',
+    id: 2,
+    name: 'Конкретные разговоры пожилых супругов ни о чём',
     city: 'Санкт-Петербург',
-    year: '2020',
-    linkView: 'https://lubimovka.ru/',
-    linkDownload: 'https://lubimovka.ru/',
+    year: 2020,
+    url_reading: 'https://lubimovka.ru/',
+    url_download: 'https://lubimovka.ru/',
+    authors: [
+      {
+        id: 1,
+        name: 'Екатерина Августеняк',
+      },
+      {
+        id: 2,
+        name: 'Антон Чехов',
+      },
+      {
+        id: 3,
+        name: 'Василий Косотрясов',
+      },
+    ],
   },
-  author: [
-    {
-      id: 1,
-      name: 'Екатерина Августеняк',
-    },
-    {
-      id: 2,
-      name: 'Антон Чехов',
-    },
-    {
-      id: 3,
-      name: 'Василий Косотрясов',
-    },
-  ],
   buttonVisibility: false,
 };
 
 export const PlayCardWithVisibleButtons = Template.bind({});
 PlayCardWithVisibleButtons.args = {
   play: {
-    title: 'Конкретные разговоры пожилых супругов ни о чём',
+    id: 3,
+    name: 'Конкретные разговоры пожилых супругов ни о чём',
     city: 'Санкт-Петербург',
-    year: '2020',
-    linkView: 'https://lubimovka.ru/',
-    linkDownload: 'https://lubimovka.ru/',
+    year: 2020,
+    url_reading: 'https://lubimovka.ru/',
+    url_download: 'https://lubimovka.ru/',
+    authors: [{
+      id: 1,
+      name: 'Екатерина Августеняк',
+    }],
   },
-  author: [{
-    id: 1,
-    name: 'Екатерина Августеняк',
-  }],
   buttonVisibility: true,
 };

--- a/src/components/ui/basic-play-card/basic-play-card.tsx
+++ b/src/components/ui/basic-play-card/basic-play-card.tsx
@@ -10,30 +10,30 @@ const cx  = cn.bind(styles);
 
 export interface IBasicPlayCardProps {
   play: {
-    title: string;
-    city: string;
-    year: string;
-    linkView: Url;
-    linkDownload: Url;
-  };
-  author: Array <{
-    id: number;
+    id?: number;
     name: string;
-  }>;
+    city: string;
+    year: number;
+    url_reading: Url;
+    url_download: Url;
+    authors: Array <{
+      id: number;
+      name: string;
+    }>;
+  };
   buttonVisibility?: boolean;
 }
 
 export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
   const {
     play,
-    author,
     buttonVisibility,
   } = props;
 
   const authorsHiddenLabel = (
     <React.Fragment>
       {
-        author.length > 1 ?
+        play.authors.length > 1 ?
           (<dt className={cx('hiddenText')}>
           Авторы:
           </dt>)
@@ -50,7 +50,7 @@ export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
       className={cx('card')}
     >
       <div className={cx('container')}>
-        <h6 className={cx('title')}>{play.title}</h6>
+        <h6 className={cx('title')}>{play.name}</h6>
         <div>
           <Button
             className={cx('buttonCustom', buttonVisibility && 'buttonVisible')}
@@ -62,7 +62,7 @@ export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
             label='Смотреть читку'
             border='top'
             isLink
-            href={play.linkView}
+            href={play.url_reading}
           />
           <Button
             className={cx('buttonCustom', buttonVisibility && 'buttonVisible')}
@@ -74,20 +74,20 @@ export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
             label='Скачать пьесу'
             border='top'
             isLink
-            href={play.linkDownload}
+            href={play.url_download}
           />
         </div>
       </div>
       <dl className={cx('info')}>
         {authorsHiddenLabel}
-        {author.map((i) => (
-          <dd className={cx('author', author.length > 1 && 'authorMultiple')} key={i.id}>
+        {play.authors.map((i) => (
+          <dd className={cx('author', play.authors.length > 1 && 'authorMultiple')} key={i.id}>
             <InfoLink
               isOutsideLink={false}
               href={`/authors/${i.id}`}
               label={i.name}
               size='l'
-              className={cx('author', author.length > 1 && 'authorMultiple')}
+              className={cx('author', play.authors.length > 1 && 'authorMultiple')}
             />
           </dd>
         )

--- a/src/components/ui/basic-play-card/basic-play-card.tsx
+++ b/src/components/ui/basic-play-card/basic-play-card.tsx
@@ -16,24 +16,24 @@ export interface IBasicPlayCardProps {
     linkView: Url;
     linkDownload: Url;
   };
-  authors: {
-    id: number,
+  author: Array <{
+    id: number;
     name: string;
-  } [];
+  }>;
   buttonVisibility?: boolean;
 }
 
 export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
   const {
     play,
-    authors,
+    author,
     buttonVisibility,
   } = props;
 
   const authorsHiddenLabel = (
     <React.Fragment>
       {
-        authors.length > 1 ?
+        author.length > 1 ?
           (<dt className={cx('hiddenText')}>
           Авторы:
           </dt>)
@@ -80,15 +80,16 @@ export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
       </div>
       <dl className={cx('info')}>
         {authorsHiddenLabel}
-        {authors.map((author) => (
-          <InfoLink
-            key={author.id}
-            isOutsideLink={false}
-            href={`/authors/${author.id}`}
-            label={author.name}
-            size='l'
-            className={cx('author', authors.length > 1 && 'authorMultiple')}
-          />
+        {author.map((i) => (
+          <dd className={cx('author', author.length > 1 && 'authorMultiple')} key={i.id}>
+            <InfoLink
+              isOutsideLink={false}
+              href={`/authors/${i.id}`}
+              label={i.name}
+              size='l'
+              className={cx('author', author.length > 1 && 'authorMultiple')}
+            />
+          </dd>
         )
         )}
         <dt className={cx('hiddenText')}>

--- a/src/components/ui/basic-play-card/basic-play-card.tsx
+++ b/src/components/ui/basic-play-card/basic-play-card.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import cn from 'classnames/bind';
 import { Button } from '../button';
 import { InfoLink } from '../info-link';
@@ -16,19 +16,34 @@ export interface IBasicPlayCardProps {
     linkView: Url;
     linkDownload: Url;
   };
-  author: {
+  authors: {
     id: number,
     name: string;
-  };
+  } [];
   buttonVisibility?: boolean;
 }
 
 export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
   const {
     play,
-    author,
+    authors,
     buttonVisibility,
   } = props;
+
+  const authorsHiddenLabel = (
+    <React.Fragment>
+      {
+        authors.length > 1 ?
+          (<dt className={cx('hiddenText')}>
+          Авторы:
+          </dt>)
+          :
+          (<dt className={cx('hiddenText')}>
+          Автор:
+          </dt>)
+      }
+    </React.Fragment>
+  );
 
   return (
     <article
@@ -64,16 +79,18 @@ export const BasicPlayCard: FC<IBasicPlayCardProps> = (props) => {
         </div>
       </div>
       <dl className={cx('info')}>
-        <dt className={cx('hiddenText')}>
-          Автор:
-        </dt>
-        <InfoLink
-          isOutsideLink={false}
-          href={`/authors/${author.id}`}
-          label={author.name}
-          size='l'
-          className={cx('author')}
-        />
+        {authorsHiddenLabel}
+        {authors.map((author) => (
+          <InfoLink
+            key={author.id}
+            isOutsideLink={false}
+            href={`/authors/${author.id}`}
+            label={author.name}
+            size='l'
+            className={cx('author', authors.length > 1 && 'authorMultiple')}
+          />
+        )
+        )}
         <dt className={cx('hiddenText')}>
           Город:
         </dt>

--- a/src/shared/styles/mixins/truncated-text.css
+++ b/src/shared/styles/mixins/truncated-text.css
@@ -1,7 +1,7 @@
 @define-mixin truncated-text $linesNumber {
   display: -webkit-box;
   overflow: hidden;
-  word-break: break-word;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: $linesNumber;
+  word-break: break-word;
 }


### PR DESCRIPTION
## Описание
Добавление функционала в BasicPlayCard для рендеринга нескольких авторов пьесы 
Предполагаю, что авторы приходят в массиве объектов, состоящим из id + имя. 

<img width="154" alt="Снимок экрана 2021-11-04 в 22 01 47" src="https://user-images.githubusercontent.com/76454288/140403220-0b5a46e9-8e6b-4c3d-a49c-7d0c6ccbb6e3.png">

## Комментарий
@borodulex Илья, так как появился дополнительный элемент (список авторов со своей шириной), для корректного отображения вернула ширину в стили .container. Знаю, что много обсуждала. Но сегодня на демо также поняла, что ширина компонента часто не совсем верная, а хотелось бы контролировать. Все комментарии принимаю 🙌

05.11
Поправлен стиль на ховер для ссылки с автором

08.11
Поправила именования свойств в интерфейсе (соответствуют данным, которые приходят с бэка)