### PR TITLE
Добавлена поддержка Safari <14 в useMediaQuery

### DIFF
--- a/src/shared/hooks/use-media-query.ts
+++ b/src/shared/hooks/use-media-query.ts
@@ -5,16 +5,21 @@ export const useMediaQuery = (query: string): boolean => {
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(query);
-
     if (mediaQueryList.matches !== matches) {
       setMatches(mediaQueryList.matches);
     }
-
     const onChange = (mediaQueryList: MediaQueryListEvent) => setMatches(mediaQueryList.matches);
 
-    mediaQueryList.addEventListener('change', onChange);
+    typeof mediaQueryList.addEventListener === 'function'
+      ? mediaQueryList.addEventListener('change', onChange)
+      // Deprecated метод для поддержки Safari <14.
+      : mediaQueryList.addListener(onChange);
 
-    return () => mediaQueryList.removeEventListener('change', onChange);
+    return () => {
+      typeof mediaQueryList.addEventListener === 'function'
+        ? mediaQueryList.removeEventListener('change', onChange)
+        : mediaQueryList.removeListener(onChange);
+    };
   }, [query]);
 
   return matches;


### PR DESCRIPTION
## Описание
Добавлена поддержка Safari <14 в useMediaQuery

## Ссылка на превью
https://lubimovka-frontend-akejmymx5-lubi.vercel.app/

## Ссылка на задачу
[Пофиксить баг с mediaQueryList в сафари](https://www.notion.so/mediaQueryList-f50f4078ac1640d6846720713de87a49)
