### PR TITLE
fix/Исправление droplist

### DIFF
--- a/src/components/ui/droplist/container-button/container-button.module.css
+++ b/src/components/ui/droplist/container-button/container-button.module.css
@@ -1,17 +1,24 @@
 .iconArrowDown {
-  width: 25px;
-  height: 25px;
-  margin-right: 9px;
+  width: scale(25px);
+  height: scale(25px);
+  margin-right: scale(9px);
+  transform: rotate(0deg);
+  transition: .3s transform;
+}
+
+.rotateUp {
+  transform: rotate(-180deg);
 }
 
 .container {
+  position: relative;
+  z-index: 99;
   display: flex;
-  width: 100%;
-  min-height: 44px;
+  min-height: scale(44px);
   box-sizing: border-box;
   align-items: center;
   justify-content: space-between;
-  border: 1px solid var(--coal);
+  border: scale(1px) solid var(--coal);
   border-top: none;
   background-color: transparent;
   color: var(--coal);
@@ -37,7 +44,7 @@
   @mixin textLarge;
   @mixin text;
 
-  margin-left: 15px;
+  margin-left: scale(15px);
   color: inherit;
   text-transform: capitalize;
 }

--- a/src/components/ui/droplist/container-button/container-button.module.css
+++ b/src/components/ui/droplist/container-button/container-button.module.css
@@ -39,4 +39,5 @@
 
   margin-left: 15px;
   color: inherit;
+  text-transform: capitalize;
 }

--- a/src/components/ui/droplist/container-button/container-button.tsx
+++ b/src/components/ui/droplist/container-button/container-button.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useCallback } from 'react';
 import cn from 'classnames';
 
-import { Icon } from '../../icon';
+import { Icon } from 'components/ui/icon';
 
 import styles from './container-button.module.css';
 
@@ -22,9 +22,10 @@ export const ContainerButton: FC<IContainerButtonProps> = ({ cb, activeDropdown,
       <p className={ cn(styles.text) }>
         { value }
       </p>
-      { <Icon glyph='arrow-down' 
+      { <Icon glyph='arrow-down'
         fill={activeDropdown ? 'white' : 'black'} 
-        className={ styles.iconArrowDown } /> }
+        className={ cn(styles.iconArrowDown, {[styles.rotateUp]: activeDropdown }) }
+      /> }
     </div>
   );
 };

--- a/src/components/ui/droplist/container-button/container-button.tsx
+++ b/src/components/ui/droplist/container-button/container-button.tsx
@@ -6,22 +6,21 @@ import { Icon } from '../../icon';
 import styles from './container-button.module.css';
 
 interface IContainerButtonProps {
-  cb: () => void,
-  activeDropdown: boolean,
+  cb: () => void
+  activeDropdown: boolean
+  value: string | number
 }
 
-export const ContainerButton: FC<IContainerButtonProps> = ({ cb, activeDropdown }) => {
+export const ContainerButton: FC<IContainerButtonProps> = ({ cb, activeDropdown, value }) => {
   const clickActiveDropdown = useCallback((): void => cb(), [ cb ]);
 
   return (
-    <div
-      className={ cn(styles.container, {
-        [styles.dark]: activeDropdown,
-      })}
-      onClick={ clickActiveDropdown }
-    >
+    <div className={ cn(styles.container, {
+      [styles.dark]: activeDropdown,
+    })}
+    onClick={ clickActiveDropdown }>
       <p className={ cn(styles.text) }>
-        Все
+        { value }
       </p>
       { <Icon glyph='arrow-down' 
         fill={activeDropdown ? 'white' : 'black'} 

--- a/src/components/ui/droplist/droplist-items/droplist-items.module.css
+++ b/src/components/ui/droplist/droplist-items/droplist-items.module.css
@@ -4,20 +4,19 @@
 
   position: relative;
   display: block;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 30px;
-  margin-bottom: 1px;
+  padding: scale(12px 0 12px 30px);
+  margin-bottom: scale(1px);
   background-color: transparent;
   cursor: pointer;
   text-transform: lowercase;
+  transition: background-color .2s ease-out;
 
   &:last-of-type {
     margin-bottom: 0;
   }
 
   &:hover {
-    background-color: var(--beige);
+    background-color: rgba(255, 255, 255, .4);
   }
 
   &::first-letter {
@@ -28,10 +27,10 @@
 .circle {
   position: absolute;
   top: 50%;
-  left: 10px;
+  left: scale(10px);
   display: block;
-  width: 10px;
-  height: 10px;
+  width: scale(10px);
+  height: scale(10px);
   background-color: var(--coal);
   border-radius: 50%;
   transform: translateY(-50%);

--- a/src/components/ui/droplist/droplist-items/droplist-items.tsx
+++ b/src/components/ui/droplist/droplist-items/droplist-items.tsx
@@ -1,21 +1,19 @@
-import React, { useState, useCallback, FC } from 'react';
+import React, { useCallback, FC } from 'react';
 import cn from 'classnames';
 
 import styles from './droplist-items.module.css';
 
 interface IDroplistItemsProps {
-  month: string | number,
+  item: string | number,
   cb: (value: string, activeCheckbox: boolean) => void,
+  activeCheckbox: boolean
 }
 
-export const DroplistItems: FC<IDroplistItemsProps> = ({ month, cb }): JSX.Element => {
-  const [ activeCheckbox, setActiveCheckbox ] = useState(false);
+export const DroplistItems: FC<IDroplistItemsProps> = ({ item, cb, activeCheckbox }): JSX.Element => {
 
   const hendlerCheckbox = useCallback((event: React.MouseEvent<HTMLInputElement>) => {
     // Январь, 2021
     const value: string = event.currentTarget.value;
-
-    setActiveCheckbox(state => !state);
     cb(value, !activeCheckbox);
   }, [ activeCheckbox ]);
 
@@ -24,10 +22,10 @@ export const DroplistItems: FC<IDroplistItemsProps> = ({ month, cb }): JSX.Eleme
       [styles.active]: activeCheckbox,
     })}>
       { activeCheckbox && <span className={ cn(styles.circle) } /> }
-      { month }
+      { item }
       <input
         type="checkbox"
-        value={ month }
+        value={ item }
         className={ cn(styles.checkbox) }
         onClick={ hendlerCheckbox }
       />

--- a/src/components/ui/droplist/droplist-items/droplist-items.tsx
+++ b/src/components/ui/droplist/droplist-items/droplist-items.tsx
@@ -18,9 +18,7 @@ export const DroplistItems: FC<IDroplistItemsProps> = ({ item, cb, activeCheckbo
   }, [ activeCheckbox ]);
 
   return (
-    <label className={ cn(styles.item, {
-      [styles.active]: activeCheckbox,
-    })}>
+    <label className={ cn(styles.item) }>
       { activeCheckbox && <span className={ cn(styles.circle) } /> }
       { item }
       <input

--- a/src/components/ui/droplist/droplist.module.css
+++ b/src/components/ui/droplist/droplist.module.css
@@ -1,5 +1,8 @@
 .dropdown {
   width: 100%;
+}
+
+.dropdownWidth {
   max-width: 300px;
 }
 

--- a/src/components/ui/droplist/droplist.module.css
+++ b/src/components/ui/droplist/droplist.module.css
@@ -1,34 +1,41 @@
-.dropdown {
+.droplist {
+  position: relative;
   width: 100%;
 }
 
-.dropdownWidth {
-  max-width: 300px;
+.droplistWidth {
+  max-width: scale(300px);
+}
+
+.form {
+  position: absolute;
+  width: inherit;
+  max-width: inherit;
 }
 
 .list {
   overflow: auto;
   max-height: 0;
-  border: 1px solid #242424;
+  border: scale(1px) solid var(--coal);
   border-top: none;
-  margin-bottom: 26px;
+  background-color: var(--beige);
   transition: all .1s ease-out;
   visibility: hidden;
 
   &::-webkit-scrollbar {
-    width: 4px;
-    height: 92px;
+    width: scale(4px);
+    height: scale(92px);
     background-color: transparent;
   }
 
   &::-webkit-scrollbar-thumb {
-    height: 92px;
+    height: scale(92px);
     background-color: var(--coal);
   }
 }
 
 .active {
   display: block;
-  max-height: 310px;
+  max-height: scale(310px);
   visibility: visible;
 }

--- a/src/components/ui/droplist/droplist.stories.tsx
+++ b/src/components/ui/droplist/droplist.stories.tsx
@@ -12,7 +12,8 @@ const Template: ComponentStory<typeof Droplist> = (args) => <Droplist {...args} 
 // Формирую массив dataType самостоятельно, из БД
 export const MonthsDroplist = Template.bind({});
 MonthsDroplist.args = {
-  type: 'months',
+  type: 'radio',
+  defaultListType: 'months',
   cb: string => {
     console.log(string);
   },
@@ -24,13 +25,12 @@ MonthsDroplist.args = {
     'September', 'Октябрь',
     'Ноябрь', 'Декабрь',
   ],
-  maxWidth: 240,
 };
 
 // Формирую массив dataType самостоятельно, из БД
 export const YearsDroplist = Template.bind({});
 YearsDroplist.args = {
-  type: 'years',
+  defaultListType: 'years',
   cb: string => {
     console.log(string);
   },
@@ -40,23 +40,21 @@ YearsDroplist.args = {
     2014, 2017,
     2020, 2021,
   ],
-  maxWidth: 150,
 };
 
 // Использую массив data по умолчанию
 export const DefaultMonthsDroplist = Template.bind({});
 DefaultMonthsDroplist.args = {
-  type: 'months',
+  defaultListType: 'months',
   cb: string => {
     console.log(string);
   },
-  widthSelectedItem: 200,
 };
 
 // Использую массив data по умолчанию
 export const DefaultYearsDroplist = Template.bind({});
 DefaultYearsDroplist.args = {
-  type: 'years',
+  defaultListType: 'years',
   cb: string => {
     console.log(string);
   },

--- a/src/components/ui/droplist/droplist.stories.tsx
+++ b/src/components/ui/droplist/droplist.stories.tsx
@@ -25,6 +25,7 @@ MonthsDroplist.args = {
     'September', 'Октябрь',
     'Ноябрь', 'Декабрь',
   ],
+  defaultValue: 'Месяц'
 };
 
 // Формирую массив dataType самостоятельно, из БД

--- a/src/components/ui/droplist/droplist.tsx
+++ b/src/components/ui/droplist/droplist.tsx
@@ -18,10 +18,11 @@ export interface IDroplistPublic {
 }
 
 interface IDroplistProps {
+  cb: (selectList: string[] | string) => void
   type?: 'checkbox' | 'radio'
-  defaultListType?: 'years' | 'months';
-  cb: (selectList: string[] | string) => void,
-  data?: string[] | number[],
+  data?: string[] | number[]
+  defaultListType?: 'years' | 'months'
+  defaultValue?: string
   ref?: React.ForwardedRef<IDroplistPublic>
   className?: 'string'
 }
@@ -30,10 +31,11 @@ interface IDroplistProps {
 export const Droplist: FC<IDroplistProps> = forwardRef((props: IDroplistProps, ref) => {
   const {
     type = 'checkbox',
-    defaultListType,
-    cb,
     data,
-    className
+    cb,
+    defaultListType,
+    className,
+    defaultValue
   } = props;
 
   // Выбранный список пользователем.
@@ -57,10 +59,16 @@ export const Droplist: FC<IDroplistProps> = forwardRef((props: IDroplistProps, r
 
   useEffect(() => {
     // Если тип 'radio' в выводимый список добавиться первый элемент переданного списка
-    if (type === 'radio') {
+    if (type === 'radio' && !defaultValue && list.length) {
       setSelectList([String(list[0]).toLowerCase()]);
     }
   }, [type, list]);
+
+  useEffect(() => {
+    if (defaultValue) {
+      setSelectList([defaultValue]);
+    }
+  }, []);
 
   const deleteItemInSelectList = (value: string) => {
     return setSelectList(state => [...state.filter((item) => item !== value.toLowerCase())]);

--- a/src/components/ui/droplist/list-selected/list-selected.module.css
+++ b/src/components/ui/droplist/list-selected/list-selected.module.css
@@ -12,13 +12,13 @@
 }
 
 .list {
-  display: grid;
+  display: flex;
   width: inherit;
   box-sizing: border-box;
+  flex-wrap: wrap;
   padding: 0 7px 3px 7px;
   margin: 0;
   column-gap: 4px;
-  grid-template-columns: repeat(auto-fit, max(112px));
   list-style: none;
   row-gap: 1px;
 }
@@ -28,7 +28,6 @@
   @mixin text;
 
   display: inline-block;
-  min-height: 35px;
   box-sizing: border-box;
   padding: 4px 8px 8px;
   background: var(--coal);

--- a/src/components/ui/droplist/list-selected/list-selected.module.css
+++ b/src/components/ui/droplist/list-selected/list-selected.module.css
@@ -1,9 +1,9 @@
 .container {
   display: flex;
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid var(--coal);
+  border: scale(1px) solid var(--coal);
   border-top: none;
+  margin-top: scale(26px);
+  background-color: var(--beige);
 }
 
 .bottom {
@@ -13,23 +13,19 @@
 
 .list {
   display: flex;
-  width: inherit;
-  box-sizing: border-box;
   flex-wrap: wrap;
-  padding: 0 7px 3px 7px;
+  padding: 0 scale(7px 3px 7px);
   margin: 0;
-  column-gap: 4px;
+  column-gap: scale(4px);
   list-style: none;
-  row-gap: 1px;
+  row-gap: .063rem;
 }
 
 .item {
   @mixin textMedium;
   @mixin text;
 
-  display: inline-block;
-  box-sizing: border-box;
-  padding: 4px 8px 8px;
+  padding: scale(4px 8px 8px);
   background: var(--coal);
   color: var(--white);
   text-align: center;
@@ -43,26 +39,23 @@
 .button {
   display: flex;
   width: 100%;
-  min-height: 35px;
+  min-height: scale(35px);
   align-items: center;
   align-self: flex-end;
   padding: 0;
   border: none;
-  margin-right: 8px;
   background-color: transparent;
-  background-position: right 8px center;
   cursor: pointer;
   transition: transform .1s linear, opacity .2s ease;
 
   &:hover {
     opacity: .8;
-    transform: translateX(4px);
+    transform: translateX(scale(4px));
   }
 }
 
 .iconArrowRight {
-  width: 25px;
-  height: 25px;
-  margin-top: 2px;
-  margin-left: auto;
+  width: scale(25px);
+  height: scale(25px);
+  margin: scale(2px 8px) 0 auto;
 }

--- a/src/components/ui/droplist/list-selected/list-selected.tsx
+++ b/src/components/ui/droplist/list-selected/list-selected.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import cn from 'classnames';
 
-import { Icon } from '../../icon';
+import { Icon } from 'components/ui/icon';
 
 import styles from './list-selected.module.css';
 
@@ -25,7 +25,7 @@ export const ListSelected: FC<IListSelectedProps> = ({ selectList }): JSX.Elemen
         <Icon 
           glyph='arrow-right' 
           fill='black' 
-          className={ styles.iconArrowRight } 
+          className={ styles.iconArrowRight }
         />
       </button>
     </div>

--- a/src/components/ui/droplist/list-selected/list-selected.tsx
+++ b/src/components/ui/droplist/list-selected/list-selected.tsx
@@ -7,27 +7,19 @@ import styles from './list-selected.module.css';
 
 interface IListSelectedProps {
   selectList: string[],
-  setMaxWidth: () => string,
 }
 
-export const ListSelected: FC<IListSelectedProps> = ({ selectList, setMaxWidth }): JSX.Element => {
+export const ListSelected: FC<IListSelectedProps> = ({ selectList }): JSX.Element => {
   return (
     <div className={ cn(styles.container, {
       [styles.bottom]: selectList.length > 1,
     })}>
-      <ul 
-        className={ cn(styles.list) } 
-        style={{ gridTemplateColumns: `repeat(auto-fit, max(${setMaxWidth()}))` }}
-      >
-        {
-          selectList.map((item, i) => {
-            return (
-              <li className={ cn(styles.item) } key={ i } >
-                { item }
-              </li>
-            );
-          })
-        }
+      <ul className={ cn(styles.list) }>
+        { selectList.map((item, i) => (
+          <li className={ cn(styles.item) } key={ i } >
+            { item }
+          </li>
+        ))}
       </ul>
       <button className={ cn(styles.button) } >
         <Icon 

--- a/src/components/ui/droplist/utils/createList.ts
+++ b/src/components/ui/droplist/utils/createList.ts
@@ -20,10 +20,11 @@ const createYearList = (data: Date): number[] => {
   return yearList;
 };
 
-export const createList = (type: string): string[] | number[] | void => {
+export const createList = (type: string | undefined): string[] | number[] => {
   const data: Date = new Date();
   switch (type) {
   case 'months': return createMonthList(data);
   case 'years': return createYearList(data);
+  default: return createMonthList(data);
   }
 };


### PR DESCRIPTION
## Описание
Расширил компонент

## Использовать ref:
```
// Импорт компонента droplist и интерфейса для useRef 
import {Droplist, IDroplistPublic} from 'components/ui/droplist';

// Импорт useRef и RefObject для типизации
import { RefObject, useRef } from 'react';

// В компоненте
const droplistRef = useRef(null) as RefObject<IDroplistPublic>;    - типизация ref

// В JSX
// Кнопка Очистить
<button onClick={() => droplistRef.current?.deleteAll()}>Очистить</button>

// Кнопка удалить один элемент
<button onClick={() => droplistRef.current?.deleteItem('март')}>deleteItem</button>

// Кнопка добавить список элементов
button onClick={() => droplistRef.current?.addSelectItems(['март'])}>addSelectItems</button>

// Дроплист 
<Droplist cb={(years: string[]) => {
console.log(years);}} ref={droplistRef} />
```

## Props

[Droplist. Список для выбора месяца и года пьесы.](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/pull/34)

`type?:` - Тип droplist. По умолчанию 'checkbox'. Выбор одного (**radio**) или нескольких элементов (**checkbox**).

`cb:` - В droplist передается колбек функция, в которой можно получать список выбранных элементов. 
##### Для типа 'radio' - элемент можно получить только один. В нем компонент с выбранными элементами отсутствует. Вместо него выбранный элемент записывается в названии кнопки открытия или закрытия дроплиста.

`data?: ` - Данные для отображения списка для выбора.

`defaultListType?: ` - Если данных нету, можно использовать список для выбора по умолчанию. Достаточно выбрать тип 
дроплиста. На данный момент доступно только 'years' и 'months'.

`className?: ` - Можно добавить класс для дроплиста. Не забудьте указать ширину для дроплиста.

`defaultValue?: ` - Название кнопки закрытия или открытия попапа при первой загрузке компонента.

`ref?: ` - Можно использовать методы из ref: 
Пример выше.
> deleteAll - очищает весь state.
> deleteItem - удаляет определённый элемент из state
> addSelectItems - добавить список элементов в state
##### state - это там где хранится выбранный список пользователем. 

## Изменения

1. Добавил необязательный пропс type с двумя вариантами: radio, checkbox. Возможность выбрать один или несколько элементов. По умолчанию checkbox.

2. Добавил [ref](https://ru.reactjs.org/docs/hooks-reference.html#useimperativehandle), в котором сохраняются методы для работы со state - selectList выбранных элементов дроплиста.

3. Переименовал `type` на `defaultListType`. Теперь этот пропс не обязателен. Теперь он отвечает за вывод списка для выбора, по умолчанию для выбранного типа дроплиста.

4. Добавлена возможность добавить свой класс. Пропс ширину убрал. Теперь ширина задается с помощью класса.
Класс добавляется с точкой. Пример: 
`.class`

5. Убрал props `maxWidth` и `widthSelectedItem` - вывод выбранного списка элементов перенес на flex. Из-за сложности встраивания функции scale в js.

## Важно
* Если добавляете класс, не забудьте добавить ширину компонента в этот класс.
При добавлении класса, вместо стандартного класса с шириной, будет подставляться Ваш.
Это сделано чтобы не было конфликта с шириной.

## Ссылка на задачу
[droplist (2 типа)](https://www.notion.so/droplist-2-ffcb553288ba45c69aa5e517be47adf7)
