### PR TITLE
Исправление верстки футера

### DIFF
--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -37,6 +37,7 @@
 
 .footnote {
   display: flex;
+  align-items: flex-start;
   margin-top: scale(49px);
   grid-area: footnote;
 
@@ -58,10 +59,7 @@
   }
 }
 
-.link {
-  color: inherit;
-  text-decoration: none;
-
+.footnoteLink {
   @media (max-width: $tablet-portrait) {
     text-decoration: underline;
   }

--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -12,7 +12,7 @@
   @media (max-width: $tablet-portrait) {
     @mixin textMedium;
 
-    padding: 0;
+    padding: scale(56px 0 11px);
     grid-template:
       "logo"
       "address"
@@ -44,7 +44,7 @@
     @mixin textCaption;
 
     flex-direction: column;
-    padding: scale(32px 28px 74px);
+    padding: scale(32px 28px 63px);
     border-top: 1px solid black;
     margin-top: scale(70px);
   }

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -7,6 +7,7 @@ import { FooterProjects } from './projects';
 import { FooterPartners } from './partners';
 import { FooterPartnerList } from './partner-list';
 import { FooterPartnerListItem } from './partner-list-item';
+import { InfoLink } from 'components/ui/info-link';
 
 import Logo from 'shared/images/logo-full.svg';
 
@@ -33,14 +34,30 @@ export const Footer = (props: IFooterProps): JSX.Element => {
         <div className={cx('copyright')}>
           &copy; Любимовка, {new Date().getFullYear()}
         </div>
-        <a href="#" className={cx('link')} target="_blank" rel="noreferrer">Политика конфиденциальности</a>
+        <InfoLink
+          isOutsideLink={true}
+          href='#'
+          label='Политика конфиденциальности'
+          hoverStyle='bottomLine'
+          size='xs'
+          textDecoration='textDecorationNone'
+          className={cx('footnoteLink')}
+        />
         <dl className={cx('credits')}>
           <div className={cx('shishki')}>
             <dt className={cx('term')}>
               дизайн сайта
             </dt>
             <dd>
-              <a className={cx('link')} href="#" target="_blank" rel="noreferrer">shishki.collective</a>
+              <InfoLink
+                isOutsideLink={true}
+                href='#'
+                label='shishki.collective'
+                hoverStyle='bottomLine'
+                size='xs'
+                textDecoration='textDecorationNone'
+                className={cx('footnoteLink')}
+              />
             </dd>
           </div>
           <div>
@@ -48,7 +65,16 @@ export const Footer = (props: IFooterProps): JSX.Element => {
               вёрстка и разработка
             </dt>
             <dd>
-              студенты <a className={cx('link')} href="#" target="_blank">Яндекс.Практикума</a>
+              студенты&nbsp;
+              <InfoLink
+                isOutsideLink={true}
+                href='#'
+                label='Яндекс.Практикума'
+                hoverStyle='bottomLine'
+                size='xs'
+                textDecoration='textDecorationNone'
+                className={cx('footnoteLink')}
+              />
             </dd>
           </div>
         </dl>

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -35,7 +35,7 @@ export const Footer = (props: IFooterProps): JSX.Element => {
           &copy; Любимовка, {new Date().getFullYear()}
         </div>
         <InfoLink
-          isOutsideLink={true}
+          isOutsideLink
           href='#'
           label='Политика конфиденциальности'
           hoverStyle='bottomLine'
@@ -50,7 +50,7 @@ export const Footer = (props: IFooterProps): JSX.Element => {
             </dt>
             <dd>
               <InfoLink
-                isOutsideLink={true}
+                isOutsideLink
                 href='#'
                 label='shishki.collective'
                 hoverStyle='bottomLine'
@@ -67,7 +67,7 @@ export const Footer = (props: IFooterProps): JSX.Element => {
             <dd>
               студенты&nbsp;
               <InfoLink
-                isOutsideLink={true}
+                isOutsideLink
                 href='#'
                 label='Яндекс.Практикума'
                 hoverStyle='bottomLine'

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -27,7 +27,6 @@ export const Footer = (props: IFooterProps): JSX.Element => {
 
   return (
     <footer className={cx('footer', className)}>
-      {children}
       <Logo className={cx('logo')}/>
       {children}
       <div className={cx('footnote')}>

--- a/src/components/ui/menu/type/footer-navigation.module.css
+++ b/src/components/ui/menu/type/footer-navigation.module.css
@@ -24,5 +24,21 @@
 .link {
   @mixin text;
 
+  position: relative;
   text-decoration: none;
+
+  &::after {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: scale(1px);
+    background-color: var(--coal);
+    content: "";
+    transition: width .5s ease-in;
+  }
+
+  &:hover::after {
+    width: 100%;
+  }
 }

--- a/src/components/ui/menu/type/footer-project-list.module.css
+++ b/src/components/ui/menu/type/footer-project-list.module.css
@@ -18,5 +18,21 @@
 .link {
   @mixin text;
 
+  position: relative;
   text-decoration: none;
+
+  &::after {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: scale(1px);
+    background-color: var(--coal);
+    content: "";
+    transition: width .5s ease-in;
+  }
+
+  &:hover::after {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Описание
* Исправила баг с повторной отрисовкой блоков футера _(дважды рендерились не только партнеры, но и блоки адреса, навигации, проектов - от этого шрифты казались жирнее)_
* переписала ссылки в Footnote, используя компонент InfoLink (в т.ч. за ради ховер)

## Ссылка на задачу
[Исправить верстку футера](https://www.notion.so/cb43e5fac4cb4df7b5d28f7d60a5a53f)
