### PR TITLE
refactoring: added icon in tags and props cb and isIcon

### DIFF
--- a/src/components/ui/tag/tag.module.css
+++ b/src/components/ui/tag/tag.module.css
@@ -17,3 +17,42 @@
     color: var(--white);
   }
 }
+
+.tagIcon {
+  display: inline-block;
+  border: 1px solid var(--coal);
+  border-top: none;
+  transition: 300ms;
+
+  &:hover,
+  &.active {
+    border: 1px solid transparent;
+    border-top: none;
+    background: var(--coal);
+    color: var(--white);
+  }
+}
+
+.tagContainer {
+  display: flex;
+  align-items: center;
+}
+
+.tagText {
+  @mixin text;
+  @mixin textMedium;
+
+  padding: 4px 0 8px 8px;
+  text-align: left;
+
+  &:hover,
+  &.active {
+    color: var(--white);
+  }
+}
+
+.icon {
+  padding-top: 4px;
+  padding-right: 4px;
+  cursor: pointer;
+}

--- a/src/components/ui/tag/tag.stories.tsx
+++ b/src/components/ui/tag/tag.stories.tsx
@@ -19,3 +19,10 @@ SelectExample.args = {
   label: 'внеконкурсная программа',
   selected: true
 };
+export const IconExample = Template.bind({});
+IconExample.args = {
+  label: 'внеконкурсная программа',
+  selected: true,
+  isIcon: true,
+  cb: console.log
+};

--- a/src/components/ui/tag/tag.tsx
+++ b/src/components/ui/tag/tag.tsx
@@ -9,21 +9,16 @@ interface ITagProps {
   isIcon?: boolean;
   cb?: (value: string) => void;
 }
-interface SyntheticEvent {
-  currentTarget: EventTarget;
-  preventDefault(): void;
-  target: EventTarget;
-}
 export const Tag: FC<ITagProps> = (props) => {
   const {
     label, selected, cb, isIcon
   } = props;
-  function handleClick(e:SyntheticEvent) {
+  const handleClick = (e:React.MouseEvent) => {
     e.preventDefault();
     if(cb) {
       cb(label);
     }
-  }
+  };
   return (
     isIcon ?
       <div className={selected ? cn(styles.tagIcon, styles.active) : cn(styles.tagIcon)}>

--- a/src/components/ui/tag/tag.tsx
+++ b/src/components/ui/tag/tag.tsx
@@ -1,22 +1,42 @@
 import { FC } from 'react';
+import {Icon} from '../icon';
 import cn from 'classnames';
 import styles from './tag.module.css';
 
 interface ITagProps {
   label: string;
   selected: boolean;
+  isIcon?: boolean;
+  cb?: (value: string) => void;
 }
-
+interface SyntheticEvent {
+  currentTarget: EventTarget;
+  preventDefault(): void;
+  target: EventTarget;
+}
 export const Tag: FC<ITagProps> = (props) => {
   const {
-    label, selected
+    label, selected, cb, isIcon
   } = props;
-
+  function handleClick(e:SyntheticEvent) {
+    e.preventDefault();
+    if(cb) {
+      cb(label);
+    }
+  }
   return (
-    <div
-      className={selected ? cn(styles.tag, styles.active) : cn(styles.tag)}
-    >
-      {label}
-    </div>
+    isIcon ?
+      <div className={selected ? cn(styles.tagIcon, styles.active) : cn(styles.tagIcon)}>
+        <div className={cn(styles.tagContainer)}>
+          <p className={selected ? cn(styles.tagText, styles.active) : cn(styles.tagText)}>{label}</p>
+          <div className={cn(styles.icon)} onClick={handleClick}>
+            <Icon glyph={'cross'}/>
+          </div>
+        </div>
+      </div>
+      :
+      <div className={selected ? cn(styles.tag, styles.active) : cn(styles.tag)}>
+        {label}
+      </div>
   );
 };

--- a/src/components/ui/tag/tag.tsx
+++ b/src/components/ui/tag/tag.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import {Icon} from '../icon';
 import cn from 'classnames';
 import styles from './tag.module.css';
@@ -13,12 +13,12 @@ export const Tag: FC<ITagProps> = (props) => {
   const {
     label, selected, cb, isIcon
   } = props;
-  const handleClick = (e:React.MouseEvent) => {
+  const handleClick = React.useCallback((e:React.MouseEvent) => {
     e.preventDefault();
     if(cb) {
       cb(label);
     }
-  };
+  },[]);
   return (
     isIcon ?
       <div className={selected ? cn(styles.tagIcon, styles.active) : cn(styles.tagIcon)}>

--- a/src/components/ui/tag/tag.tsx
+++ b/src/components/ui/tag/tag.tsx
@@ -18,7 +18,7 @@ export const Tag: FC<ITagProps> = (props) => {
     if(cb) {
       cb(label);
     }
-  },[]);
+  },[cb]);
   return (
     isIcon ?
       <div className={selected ? cn(styles.tagIcon, styles.active) : cn(styles.tagIcon)}>


### PR DESCRIPTION
## Описание
Сделал рефакторинг компонента Tags. Добавил возможность добавления иконки крестика в компонент в соответствии с изменением дизайна. Добавил в пропсы функцию колбэк - которая срабатывает при нажатии на иконку.

## Ссылка на задачу
[Refactoring tags](https://www.notion.so/Front-52aae4efcc1743f58f4abf64bf7357ff?p=948f9071c27840768796e3c0a8fc7311)
