### PR TITLE
fix: обновить мок-карточку для пьес библиотеки

### DIFF
--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -6,15 +6,15 @@ import LibraryPage from 'components/library-pieces-page';
 
 const mockCard = {
   play: {
-    name: 'Конкретные разговоры пожилых супругов ни о чём',
+    title: 'Конкретные разговоры пожилых супругов ни о чём',
     city: 'Санкт-Петербург',
-    year: 2020,
-    url_reading: 'https://lubimovka.ru/',
-    url_download: 'https://lubimovka.ru/',
-    authors: [{
-      id: 1,
-      name: 'Екатерина Августеняк',
-    }]
+    year: '2020',
+    linkView: 'https://lubimovka.ru/',
+    linkDownload: 'https://lubimovka.ru/',
+  },
+  author: {
+    id: 1,
+    name: 'Екатерина Августеняк',
   }
 };
 


### PR DESCRIPTION
## Описание
Обновить мок-карточку для пьес библиотеки

## Ссылка на задачу
Задачи нет, небольшие изменения, чтобы страница library собиралась без ошибок, т.к. изменилась структура у пропсов BasicPlayCard
