### PR TITLE
Fix library filter year

### DIFF
--- a/src/components/library-pieces-page/index.tsx
+++ b/src/components/library-pieces-page/index.tsx
@@ -119,9 +119,9 @@ const LibraryPage: FC<ILibraryPageProps> = ({ isLoading, items, years, programme
             </>
           )}
         </section>
-        {isModalOpen && (<LibraryFiltersModal><LibraryFilter years={years} programmes={programmes}
+        <LibraryFiltersModal isModalOpen={isModalOpen}><LibraryFilter years={years} programmes={programmes}
           filterDispatcher={filterDispatcher} onCheckResults={handleFiltersClick}
-          droplistRef={droplistRef}/></LibraryFiltersModal>)}
+          droplistRef={droplistRef}/></LibraryFiltersModal>
       </div>
     </main>
   );

--- a/src/components/library-pieces-page/index.tsx
+++ b/src/components/library-pieces-page/index.tsx
@@ -64,7 +64,8 @@ const LibraryPage: FC<ILibraryPageProps> = ({ isLoading, items, years, programme
             </Menu>
           </div>
           <div className={styles.mobileTags}>
-            <LibraryTagsMobile programmes={programmes} filterDispatcher={filterDispatcher}/>
+            <LibraryTagsMobile programmes={programmes} filterDispatcher={filterDispatcher}
+              droplistRef={droplistRef}/>
           </div>
           <div className={styles.filter}>
             <LibraryFilter years={years} programmes={programmes}

--- a/src/components/library-pieces-page/library-filters-modal/index.module.css
+++ b/src/components/library-pieces-page/library-filters-modal/index.module.css
@@ -9,14 +9,14 @@
   flex-direction: column;
   padding: scale(103px) scale(24px) scale(56px);
   background-color: var(--beige);
+  opacity: 0;
   transition: visibility .5s, opacity .5s linear;
   visibility: hidden;
-  opacity: 0;
 }
 
 .isOpen {
   z-index: 1;
   opacity: 1;
-  visibility: visible;
   transition: visibility .5s, opacity .5s linear;
+  visibility: visible;
 }

--- a/src/components/library-pieces-page/library-filters-modal/index.module.css
+++ b/src/components/library-pieces-page/library-filters-modal/index.module.css
@@ -2,7 +2,6 @@
   position: fixed;
   top: 0;
   left: 0;
-  display: none;
   overflow: auto;
   width: 100%;
   height: 100%;
@@ -10,8 +9,14 @@
   flex-direction: column;
   padding: scale(103px) scale(24px) scale(56px);
   background-color: var(--beige);
+  transition: visibility .5s, opacity .5s linear;
+  visibility: hidden;
+  opacity: 0;
+}
 
-  @media (max-width: $tablet-portrait) {
-    display: flex;
-  }
+.isOpen {
+  z-index: 1;
+  opacity: 1;
+  visibility: visible;
+  transition: visibility .5s, opacity .5s linear;
 }

--- a/src/components/library-pieces-page/library-filters-modal/index.tsx
+++ b/src/components/library-pieces-page/library-filters-modal/index.tsx
@@ -1,14 +1,18 @@
+import classNames from 'classnames/bind';
 import { FC, ReactNode } from 'react';
 
 import styles from './index.module.css';
 
 interface ILibraryFiltersModalProps {
   children: ReactNode;
+  isModalOpen: boolean;
 }
 
-const LibraryFiltersModal: FC<ILibraryFiltersModalProps> = ({ children }) => {
+const cx = classNames.bind(styles);
+
+const LibraryFiltersModal: FC<ILibraryFiltersModalProps> = ({ children, isModalOpen }) => {
   return (
-    <section className={styles.wrap}>
+    <section className={cx('wrap', { [styles.isOpen]: isModalOpen })}>
       {children}
     </section>
   );

--- a/src/components/library-tags-mobile/library-tags-mobile.tsx
+++ b/src/components/library-tags-mobile/library-tags-mobile.tsx
@@ -1,18 +1,20 @@
-import React, { FC, useCallback, Dispatch, useContext, useMemo } from 'react';
+import React, { FC, useCallback, Dispatch, useContext, useMemo, RefObject } from 'react';
 
 import { Action } from 'components/library-filter/library-filter-reducer';
 import CurrentFiltersContext from 'pages/library/library-filters-context';
 import { IProgram } from 'pages/library';
 import { Tag } from 'components/ui/tag';
+import { IDroplistPublic } from 'components/ui/droplist';
 
 import styles from './library-tags-mobile.module.css';
 
 export interface LibraryTagsMobileProps {
   programmes: Array<IProgram>;
   filterDispatcher: Dispatch<Action>;
+  droplistRef: RefObject<IDroplistPublic>;
 }
 
-const LibraryTagsMobile: FC <LibraryTagsMobileProps> = ({ programmes, filterDispatcher }) => {
+const LibraryTagsMobile: FC <LibraryTagsMobileProps> = ({ programmes, filterDispatcher, droplistRef }) => {
   const filterState = useContext(CurrentFiltersContext);
 
   const selectedProgrammes = useMemo(()=> {
@@ -24,14 +26,15 @@ const LibraryTagsMobile: FC <LibraryTagsMobileProps> = ({ programmes, filterDisp
       filterDispatcher({ type: 'remove programme', program: el });
     }, [filterDispatcher]);
 
-  const handleYearsClick = useCallback((year: string): void => {
+  const handleYearClick = useCallback((year: string): void => {
     filterDispatcher({ type: 'remove year', festival: year });
-  }, [filterDispatcher]);
+    droplistRef.current?.deleteItem(year);
+  }, [filterDispatcher, droplistRef]);
 
   return (
     <ul className={styles.programmesList}>
       {filterState.festival.map((year, idx) => (
-        <li onClick={() => handleYearsClick(String(year))} className={styles.programme} key={idx}>
+        <li onClick={() => handleYearClick(String(year))} className={styles.programme} key={idx}>
           <Tag label={String(year)} selected={true} isIcon={true}/></li>
       ))}
       {selectedProgrammes.map(({ pk, name }) => (


### PR DESCRIPTION
## Задача в Notion:
https://www.notion.so/Front-52aae4efcc1743f58f4abf64bf7357ff?p=cb14aabe5673422b99df49e60b1a95ca

## Описание
1. Исправила реализацию верстки модального окна с фильтрами - сохраняются года при закрытии/открытии модального окна
2. Удаление элемента года из стейта и из списка выбранных годов компонента droplist