### PR TITLE
Исправление багов на странице обратной связи

### DIFF
--- a/src/components/author-page/overview/overview.tsx
+++ b/src/components/author-page/overview/overview.tsx
@@ -148,7 +148,7 @@ export const AuthorOverview: FC<IAuthorOverview> = ({ props }) => {
             <p className={cx('email')}>E-mail для связи</p>
             <InfoLink
               isOutsideLink={true}
-              href={`mailto://${email}`}
+              href={`mailto:${email}`}
               label={email}
               size="l"
               textDecoration="underline"

--- a/src/components/author-page/request/request.tsx
+++ b/src/components/author-page/request/request.tsx
@@ -20,7 +20,7 @@ export const AuthorRequest: FC = () => {
           нам на&nbsp;
         <InfoLink
           isOutsideLink={true}
-          href="mailto://autors@lubimovka.ru"
+          href="mailto:autors@lubimovka.ru"
           label="autors@lubimovka.ru"
           size="l"
           textDecoration="underline"

--- a/src/components/contacts-authors/contacts-authors.module.css
+++ b/src/components/contacts-authors/contacts-authors.module.css
@@ -15,10 +15,11 @@
   margin: scale(16px 0 0 60px);
 }
 
+.emailContainer {
+  margin-top: scale(24px);
+}
+
 .email {
   @mixin headline;
   @mixin headline6;
-
-  display: block;
-  margin-top: scale(24px);
 }

--- a/src/components/contacts-authors/contacts-authors.tsx
+++ b/src/components/contacts-authors/contacts-authors.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames/bind';
 
+import { InfoLink } from 'components/ui/info-link/info-link';
+
 import styles from './contacts-authors.module.css';
 
 const cx = classNames.bind(styles);
@@ -17,9 +19,15 @@ const ContactsAuthors = (props: IContactsAuthorsProps): JSX.Element => {
         Если вы хотите внести изменения в свою страницу: добавить пьесы, ссылки
         на статьи или публикации, напишите нам. Приложите файлы и ссылки.
       </p>
-      <a className={cx('email')} href={`mailto:${email}`}>
-        {email}
-      </a>
+      <div className={cx('emailContainer')}>
+        <InfoLink
+          className={cx('email')}
+          isOutsideLink={true}
+          href={`mailto:${email}`}
+          label={email}
+          textDecoration="underline"
+        />
+      </div>
     </address>
   );
 };

--- a/src/components/contacts-title/contacts-title.tsx
+++ b/src/components/contacts-title/contacts-title.tsx
@@ -13,7 +13,7 @@ const ContactsTitle = (props: IContactsTitleProps): JSX.Element => {
 
   return (
     <h1 id={id} className={cx('title')}>
-        Если вам есть, чем поделиться или хотите задать вопрос
+        Если вам есть чем поделиться или хотите задать вопрос
     </h1>
   );
 };

--- a/src/components/donation-page/report/report.tsx
+++ b/src/components/donation-page/report/report.tsx
@@ -22,7 +22,7 @@ export const Report: FC<IReportProps> = (props) => {
         <InfoLink
           className={cx('reportEmail')}
           isOutsideLink={true}
-          href={`mailto://${email}`}
+          href={`mailto:${email}`}
           label={email}
           textDecoration="underline"
         />

--- a/src/components/for-press-hero/for-press-hero-pr-contact/for-press-hero-pr-contact.tsx
+++ b/src/components/for-press-hero/for-press-hero-pr-contact/for-press-hero-pr-contact.tsx
@@ -37,7 +37,7 @@ export const ForPressHeroPrContact: FC<IForPressHeroPrContactProps> = ({ data, c
         <dd className={cx('email')}>
           <InfoLink
             isOutsideLink={true}
-            href={`mailto://${data.email}`}
+            href={`mailto:${data.email}`}
             label={data.email}
             size= "l"
             textDecoration="underline"

--- a/src/components/team-page/volunteers/section/volunteers-section.tsx
+++ b/src/components/team-page/volunteers/section/volunteers-section.tsx
@@ -50,7 +50,7 @@ const VolunteersSection: FC<VolunteersSectionProps> = (props) => {
           <p className={cx('info')}>
             Если вы хотите быть волонтером, напишите нам на
             <InfoLink
-              href={'mailto://job@lubimovka.ru'}
+              href={'mailto:job@lubimovka.ru'}
               isOutsideLink={true}
               label={'job@lubimovka.ru'}
               size={'xl'}

--- a/src/components/trustees-section/trustees-section.tsx
+++ b/src/components/trustees-section/trustees-section.tsx
@@ -28,7 +28,7 @@ const TrusteesSection: FC<TrusteesSectionProps> = ({ text, children }) => {
           <Icon glyph={'asterisk'}/>
           <p className={style.accent}>{accent}
             <InfoLink
-              href={'mailto://job@lubimovka.ru'}
+              href={'mailto:job@lubimovka.ru'}
               isOutsideLink={true}
               label={link}
               size={'xl'}

--- a/src/components/ui/info-link/info-link.stories.tsx
+++ b/src/components/ui/info-link/info-link.stories.tsx
@@ -23,7 +23,7 @@ SocialMediaLink.args = {
 export const LinkInTextBlocks = Template.bind({});
 LinkInTextBlocks.args = {
   isOutsideLink: true,
-  href: 'mailto://more@lubimovka.ru',
+  href: 'mailto:more@lubimovka.ru',
   label: 'more@lubimovka.ru',
   size: 'l',
   textDecoration: 'underline'

--- a/src/components/ui/text-area/text-area.module.css
+++ b/src/components/ui/text-area/text-area.module.css
@@ -4,6 +4,7 @@
 
   display: block;
   width: 100%;
+  max-width: 100%;
   height: auto;
   padding: scale(8px);
   border: 0;

--- a/src/components/ui/text-area/text-area.module.css
+++ b/src/components/ui/text-area/text-area.module.css
@@ -18,6 +18,19 @@
     opacity: .7;
   }
 
+  &::-webkit-scrollbar {
+    width: scale(4px);
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--coal);
+  }
+
+  &::-webkit-resizer {
+    background-color: var(--coal);
+  }
+
   &:focus {
     border-right: 1px solid var(--coal);
   }

--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -156,7 +156,7 @@ const Contacts: NextPage = () => {
                 />
               </Form.Actions>
               <Form.Disclaimer>
-                {'Нажимая на кнопку «Отправить» вы даёте согласие'}
+                {'Нажимая на кнопку «Отправить» вы даёте согласие '}
                 <Link href="/privacy-policy">
                   <a>на обработку персональных данных </a>
                 </Link>


### PR DESCRIPTION
## Описание
Исправляет баги на странице обратной связи

- исправлена пуктуационная ошибка`Если вам есть, чем поделиться...` =>  `Если вам есть чем поделиться...`
- добавлен пробел `согласиена обработку персональных данных` => `согласие на обработку персональных данных`
- поле Текста сообщения теперь тянется только вертикально
- адрес электронной почты переписан с использованием компонента `InfoLink`, описывающий соответствующую анимацию ховера
- скроллбар и ресайзер стилизован в одном стиле с остальными скроллбарами на сайте

также попутно исправлены гиперссылки `mailto://${email}` => `mailto:${email}`

## Ссылка на задачи

- [На странице "Контакты" в тексте заголовка допущена пунктуационная ошибка. После "есть" убрать запятую](https://www.notion.so/ba35a730bd1148fd9f4c537a23354224)
- [На странице "Контакты" текст пояснения и текст гиперссылки написаны слитно](https://www.notion.so/766682c1cd1d4d9c9ea9de12ac85e2ae)
- часть багов задачи [На странице "Контакты" в поле ввода "Текст сообщения" нет ограничения по длине вводимого сообщения](https://www.notion.so/86e229692cb445dda5881384b81e5793)
- [На странице "Контакты" при наведении курсором на почту, не отображается анимация](https://www.notion.so/6e64e53c78a14bff89e4a891282474d5)
- [На странице "Контакты" в поле ввода "Текст сообщения" внешний вид слайдера не в одном стиле с остальными слайдерами на сайте](https://www.notion.so/965b9fd2e44b45f6b9ef3c17a35a4aa5)

**прошу мнения** когда текстовое поле формы обратной связи в фокусе, правая граница чуть отодвигает ресайзер, так что он и скроллбар стоят чуть не в линию. Насколько это критично? Нужно ли заморачиваться?
![Screen Shot 2022-01-28 at 3 19 33 PM](https://user-images.githubusercontent.com/76534205/151625680-56407f92-d0bb-4603-b8be-8d066cd7456c.png)



