### PR TITLE
Исправление багов футера (все страницы)

### DIFF
--- a/src/components/footer-partner-list/footer-partner-list.module.css
+++ b/src/components/footer-partner-list/footer-partner-list.module.css
@@ -3,6 +3,7 @@
   flex-wrap: wrap;
   padding: 0;
   margin: 0;
+  margin: calc(-1 * scale(10px)) 0;
 
   @media (max-width: $tablet-portrait) {
     display: flex;

--- a/src/components/footer-partner-list/item/footer-partner-list-item.module.css
+++ b/src/components/footer-partner-list/item/footer-partner-list-item.module.css
@@ -1,5 +1,6 @@
 .item {
   display: block;
+  margin: scale(10px) 0;
 
   @media (max-width: $tablet-portrait) {
     display: flex;

--- a/src/components/ui/info-link/info-link.module.css
+++ b/src/components/ui/info-link/info-link.module.css
@@ -38,7 +38,7 @@
     left: 0;
     display: block;
     width: 0;
-    height: scale(1px);
+    height: 1px;
     background-color: var(--coal);
     content: "";
     transition: width .5s ease-in;

--- a/src/components/ui/menu/type/footer-navigation.module.css
+++ b/src/components/ui/menu/type/footer-navigation.module.css
@@ -25,28 +25,14 @@
   @mixin text;
   @mixin textCaption;
 
-  position: relative;
+  background-image: linear-gradient(var(--coal), var(--coal));
+  background-position: 0% 100%;
+  background-repeat: no-repeat;
+  background-size: 0% 1px;
   text-decoration: none;
+  transition: background-size .5s;
 
-  &:hover::after {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 1px;
-    animation: underline .5s;
-    background-color: var(--coal);
-    content: "";
-    transform-origin: 0;
-  }
-}
-
-@keyframes underline {
-  0% {
-    transform: scaleX(0);
-  }
-
-  100% {
-    transform: scaleX(1);
+  &:hover {
+    background-size: 100% 1px;
   }
 }

--- a/src/components/ui/menu/type/footer-navigation.module.css
+++ b/src/components/ui/menu/type/footer-navigation.module.css
@@ -33,7 +33,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    height: scale(1px);
+    height: 1px;
     animation: underline .5s;
     background-color: var(--coal);
     content: "";

--- a/src/components/ui/menu/type/footer-project-list.module.css
+++ b/src/components/ui/menu/type/footer-project-list.module.css
@@ -27,7 +27,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    height: scale(1px);
+    height: 1px;
     animation: underline .5s;
     background-color: var(--coal);
     content: "";

--- a/src/components/ui/menu/type/footer-project-list.module.css
+++ b/src/components/ui/menu/type/footer-project-list.module.css
@@ -19,28 +19,14 @@
   @mixin text;
   @mixin textCaption;
 
-  position: relative;
+  background-image: linear-gradient(var(--coal), var(--coal));
+  background-position: 0% 100%;
+  background-repeat: no-repeat;
+  background-size: 0% 1px;
   text-decoration: none;
+  transition: background-size .5s;
 
-  &:hover::after {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 1px;
-    animation: underline .5s;
-    background-color: var(--coal);
-    content: "";
-    transform-origin: 0;
-  }
-}
-
-@keyframes underline {
-  0% {
-    transform: scaleX(0);
-  }
-
-  100% {
-    transform: scaleX(1);
+  &:hover {
+    background-size: 100% 1px;
   }
 }

--- a/src/shared/styles/mixins/visually-hidden.css
+++ b/src/shared/styles/mixins/visually-hidden.css
@@ -1,5 +1,6 @@
 @define-mixin visually-hidden {
   position: absolute;
+  overflow: hidden;
   width: 1px;
   height: 1px;
   margin: -1px;
@@ -8,6 +9,7 @@
 
 @define-mixin undo-visually-hidden {
   position: static;
+  overflow: visible;
   width: auto;
   height: auto;
   margin: 0;


### PR DESCRIPTION
## Описание

- исправлен баг с отрисовкой ховер-эффекта ссылок футера (убран скейлинг для значений в 1px)
- добавлен отступ между строк логотипов генеральных партнеров. В макете такой отступ не предусмотрен - установила - в 20px. На мобильной версии отступ также отсутствовал. Сымитировала row-gap внешними отступами для элементов + отрицательными внешними отступами для контейнера (кроссбраузерности ради).
- миксину `visually-hidden` добавлено свойство `overflow: hidden;`

также попутно улучшен ховер-эффект для многострочных ссылок:
анимация нижнего подчеркивания работала только для одной строки (последней в Chrome, первой в Firefox)
![Screen Shot 2022-01-29 at 12 51 52 PM](https://user-images.githubusercontent.com/76534205/151673829-d45bdb69-0fa8-44c5-ad4b-19303b5100e8.png)

=> 
анимация работает для всех строк
![Screen Shot 2022-01-29 at 12 52 26 PM](https://user-images.githubusercontent.com/76534205/151673793-bc096950-1cca-4324-a440-b04a461cdb62.png)


## Ссылки на задачи

- [Часть текстовых кнопок в футере при наведении подчеркивается жирной линией, а часть тонкой](https://www.notion.so/6ce8a1477c5f4fbca4c224f499ab4cd1)
- [Отсутствует отступ между строк у логотипов генеральных партнеров](https://www.notion.so/355f8347a2fc42be8379bfec9e37de98)
- [Mob web. Афиша событий. Главные партнеры не имеют отступа друг от друга и  описание](https://www.notion.so/Mob-web-725d78e31c344ba18db1fe983bcc1033)
- [Mob web. стр Проекта. По всей странице есть отступ справа. Блоки не на всю страницу экрана.](https://www.notion.so/Mob-web-eaddb5c3aaf44091a3ded3ff43c73a2e)