### PR TITLE
Исправление багов на странице проекта

### DIFF
--- a/src/components/project-layout/storey/project-layout-storey.module.css
+++ b/src/components/project-layout/storey/project-layout-storey.module.css
@@ -22,6 +22,10 @@
 
 .videos {
   margin-top: scale(98px);
+
+  @media (max-width: $tablet-portrait) {
+    padding-left: 0;
+  }
 }
 
 .photos {
@@ -31,14 +35,26 @@
 
 .plays {
   margin-top: scale(94px);
+
+  @media (max-width: $tablet-portrait) {
+    padding: 0;
+  }
 }
 
 .performances {
   margin-top: scale(124px);
+
+  @media (max-width: $tablet-portrait) {
+    padding: 0;
+  }
 }
 
 .persons {
   margin-top: scale(124px);
+
+  @media (max-width: $tablet-portrait) {
+    padding: 0;
+  }
 }
 
 .text {

--- a/src/components/project-layout/storey/project-layout-storey.module.css
+++ b/src/components/project-layout/storey/project-layout-storey.module.css
@@ -51,11 +51,21 @@
 }
 
 .invitation {
+  padding-bottom: scale(169px);
   margin-top: scale(100px);
+
+  @media (max-width: $tablet-portrait) {
+    padding-bottom: 0;
+  }
 
   .holder {
     max-width: scale(516px);
-    margin-right: scale(200px);
+    margin-right: scale(227px);
     margin-left: auto;
+
+    @media (max-width: $tablet-portrait) {
+      margin-right: 0;
+      margin-left: 0;
+    }
   }
 }

--- a/src/components/project-layout/storey/project-layout-storey.module.css
+++ b/src/components/project-layout/storey/project-layout-storey.module.css
@@ -25,6 +25,7 @@
 }
 
 .photos {
+  padding: 0;
   margin-top: scale(144px);
 }
 

--- a/src/components/ui/project-card/project-card.module.css
+++ b/src/components/ui/project-card/project-card.module.css
@@ -90,9 +90,9 @@
 }
 
 .even {
-  .imageContainer {
+  .image {
     @media (max-width: $tablet-portrait) {
-      justify-content: end;
+      margin-left: auto;
     }
   }
 }

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -23,6 +23,8 @@ import { PersonCardList } from 'components/person-card-list';
 import { fetcher } from 'shared/fetcher';
 import { Project as ProjectModel } from 'api-typings';
 
+const convertRolesToString = (roles: PersonRole[]) => roles.map(role => role.name).join(', ');
+
 const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element => {
   const {
     title,
@@ -136,12 +138,13 @@ const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>):
               <ProjectLayout.Storey type="persons">
                 <Section title={content_item.title}>
                   <PersonCardList>
-                    {content_item.items.map(({ id, first_name, last_name, image }) => (
+                    {content_item.items.map(({ id, first_name, last_name, image, roles }) => (
                       <PersonCard
                         key={id}
                         name={`${first_name} ${last_name}`}
                         image={image}
-                        participant={false}
+                        participant={true}
+                        about={convertRolesToString(roles)}
                       />
                     ))}
                   </PersonCardList>

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -70,7 +70,7 @@ const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>):
               <ProjectLayout.Storey type="plays">
                 <Section title={content_item.title}>
                   <BasicPlayCardList>
-                    {content_item.items.map(({ id, name, city, year, url_download, url_reading }) => (
+                    {content_item.items.map(({ id, name, city, year, url_download, url_reading, authors }) => (
                       <BasicPlayCard
                         key={id}
                         play={{
@@ -79,11 +79,7 @@ const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>):
                           year,
                           linkView: url_reading,
                           linkDownload: url_download,
-                          authors:[{
-                            // TODO: добавить реальные данные в ответ бекенда
-                            id: 0,
-                            name: 'Константин Константинопольский',
-                          }]
+                          authors: authors,
                         }}
                       />
                     ))}

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -42,8 +42,7 @@ const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>):
         </PageBreadcrumbs>
         <ProjectHeadline
           title={title}
-          //TODO: добавить поле в ответ бекенда
-          intro=""
+          intro={description}
           image={image}
         />
         <ProjectLayout.Description>


### PR DESCRIPTION
## Описание

- добавлены данные с сервера: интро проекта, роли персоны, авторы пьесы
- убраны боковые отступы блока с фотографиями, добавлен нижний отступ блока о сотрудничестве

также попутно приведены в соответствие с макетом: блок о сотрудничестве (`.holder`) и боковые отступы секций на планшетах/мобильных

## Ссылка на задачи

- [На странице проекта не отображаются короткое интро](https://www.notion.so/331e3b363ba8462695d2f68e51e7cc09)
- [На странице проекта в блоке персон не отображается роль персоны](https://www.notion.so/9a140b68fbf04f6092f76a62fe475d6a)
- [На странице проекта изображения в блоке с изображениями отображаются с отступами слева и справ от края браузера](https://www.notion.so/985be13c7ba642a59b42190e03f47548)
- [На странице проекта блок "Проект открыт к сотрудничеству..." расположен с маленьким отступом от футера](https://www.notion.so/8fa2a6d6191349b897f46c37179eb1cd)
- [страница Проекта. Блок пьес. При добавлении пьесы в блок отображается неверное имя автора пьесы.](https://www.notion.so/bddf09b411a54de8863909f26d9ff60d)

-[Mob web. Страница Проекты. Элементы проектов не отображаются плиткой в шахматном порядке.](https://www.notion.so/Mob-web-a6ee776361b9448e86a9c3e3050f6a4f)

в этом же ПР

- поправила верстку списка проектов на странице /projects. Flexbox cвойство `justify-content: end;` контейнера изображения для четных карточек отрабатывало не во всех мобильных браузеров. Заменила на `margin-left: auto;` для самого изображения.