### PR TITLE
Исправление передачи данных в блок команды спектакля

### DIFF
--- a/src/components/performance-crew/performance-crew.tsx
+++ b/src/components/performance-crew/performance-crew.tsx
@@ -1,7 +1,7 @@
 import { FC, Fragment } from 'react';
 import classNames from 'classnames/bind';
 
-import { Crewman } from 'shared/types';
+import { Crewman, Persons } from 'shared/types';
 
 import styles from './performance-crew.module.css';
 
@@ -11,36 +11,23 @@ export interface IPerformanceCrewProps {
   crew: Crewman[],
 }
 
-const getRoleTitle = (roleId: string) => ({
-  adapter: 'Адаптация текста',
-  dramatist: 'Драматург',
-  director: 'Режиссёр',
-  interpreter: 'Перевод',
-}[roleId.toLocaleLowerCase()]);
+const convertNamesToString = (persons: Persons) => persons.map(person => person).join(', ');
 
 export const PerformanceCrew: FC<IPerformanceCrewProps> = (props) => {
   const { crew } = props;
 
-  const [actors, restCrew] = crew.reduce<Crewman[][]>(([a, r], crewman) => crewman.role === 'Actor' ? [[...a, crewman], r] : [a, [...r, crewman]], [[], []]);
-
   return (
     <dl className={cx('list')}>
-      {restCrew.map(({ name, role }) => (
+      {crew.map(({ persons, name }) => (
         <Fragment key="role">
           <dt className={cx('title')}>
-            {getRoleTitle(role)}
+            {name}
           </dt>
           <dd className={cx('description')}>
-            {name}
+            {convertNamesToString(persons)}
           </dd>
         </Fragment>
       ))}
-      <dt className={cx('title')}>
-        Актёры
-      </dt>
-      <dd className={cx('description')}>
-        {actors.map(({ name }) => name).join(', ')}
-      </dd>
     </dl>
   );
 };

--- a/src/pages/performances/[id].tsx
+++ b/src/pages/performances/[id].tsx
@@ -25,7 +25,7 @@ import { Performance as PerformanceModel } from 'api-typings';
 const Performance = (props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element => {
   const {
     play,
-    persons,
+    team,
     images_in_block,
     name,
     main_image,
@@ -103,7 +103,7 @@ const Performance = (props: InferGetServerSidePropsType<typeof getServerSideProp
             duration="1 ч. 15 мин."
             ageLimit={age_limit}
           />
-          <PerformanceCrew crew={persons}/>
+          <PerformanceCrew crew={team}/>
         </PerformanceLayout.Aside>
         <PerformanceLayout.Gallery>
           <PhotoGallery>

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -16,7 +16,9 @@ export type Partner = {
   url?: Url,
 }
 
+export type Persons = string[];
+
 export type Crewman = {
   name: string,
-  role: 'Actor' | 'Adapter' | 'Dramatist' | 'Director' |'Interpreter',
+  persons: Persons,
 }


### PR DESCRIPTION
## Описание
исправляет баг, связанных с невозможностью перейти на страницу спектакля,
корректно отрисовывает блок команды на странице спектакля

## Ссылка на задачу
[Не осуществляется переход на страницу Спектакль — Performance page путем страница проекты — спектакли — о спектакле](https://www.notion.so/Performance-page-4c8026cee2ea4b6e8fcd985b5e783391)
[Не осуществляется переход на страницу Спектакль — Performance page путем страница афиша — о спектакле](https://www.notion.so/Performance-page-541a2bf87c7c465abe2c342d020b9a13)

** не могу проверить переход по соответствующим ссылкам:
1. на странице /main, т.к. отсутствует блок со спектаклями (похоже с сервера не приходит данных ни об одном спектакле)
![Screen Shot 2022-01-30 at 4 24 48 PM](https://user-images.githubusercontent.com/76534205/151720724-7bb50baf-96fc-4a08-ad40-a4458e9fdf79.png)
2. на странице /afishe, т.к. ссылки отсутствуют
![Screen Shot 2022-01-30 at 4 14 01 PM](https://user-images.githubusercontent.com/76534205/151720726-7e7ae7c9-e643-4151-a7d9-eaaae7c4d7ad.png)
