### PR TITLE
fix: уменьшить размер preloader'а на странице библиотеки

### DIFF
--- a/src/components/library-pieces-page/index.module.css
+++ b/src/components/library-pieces-page/index.module.css
@@ -189,6 +189,21 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: scale(50px);
+
+  @media (max-width: $tablet-portrait) {
+    display: none;
+  }
+}
+
+.loaderMobile {
+  display: none;
+
+  @media (max-width: $tablet-portrait) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }
 
 .pieces {

--- a/src/components/library-pieces-page/index.tsx
+++ b/src/components/library-pieces-page/index.tsx
@@ -115,7 +115,9 @@ const LibraryPage: FC<ILibraryPageProps> = ({ isLoading, items, years, programme
             </p>
           }
           {isLoading ? (
-            <LibraryPreloader/>
+            <div className={styles.loaderMobile}>
+              <LibraryPreloader/>
+            </div>
           ) : (
             <>
               {items.map(({ id, name, city, year, url_download, url_reading, authors }) => (

--- a/src/components/library-pieces-page/library-preloader/library-preloader.tsx
+++ b/src/components/library-pieces-page/library-preloader/library-preloader.tsx
@@ -5,7 +5,7 @@ import Loader from './loader.gif';
 
 const LibraryPreloader: FC = () => {
   return (
-    <Image src={Loader} alt="Прелоадер"/>
+    <Image width={59} height={56} src={Loader} alt="Прелоадер"/>
   );
 };
 


### PR DESCRIPTION
## Описание
Уменьшает размер gif-картинки preloader'а на странице библиотеки

## Ссылка на задачу
[Поправить прелоадер библиотеки](https://www.notion.so/76acbe25aaac45adbc584ecf218b8b66)
