### PR TITLE
Добавление volume для swag - для сохранения сертификатов и решения пр…

### DIFF
--- a/infra_deploy/stage/lubimovka_frontend_stage_deploy.yml
+++ b/infra_deploy/stage/lubimovka_frontend_stage_deploy.yml
@@ -18,6 +18,7 @@ services:
       - stage_swag_network
     volumes:
       - ./swag/swag_nginx_stage.conf:/config/nginx/site-confs/default
+      - swag_volume_stage:/config
       - static_value_stage:/config/stage/static/
       - media_value_stage:/config/stage/media/
     ports:
@@ -48,3 +49,5 @@ volumes:
     name: static_value_stage
   media_value_stage:
     name: media_value_stage
+  swag_volume_stage:
+    name: swag_volume_stage


### PR DESCRIPTION
Добавление volume для swag - для сохранения сертификатов и решения проблем с получением сертификата (сейчас сертификат генерируется при каждом деплое и бывают случаи, когда swag/zerossl его не выдает и требуется перезапуск контейнера)

## Описание
Что делает этот Pull Request?

## Ссылка на задачу
[Название задачи](ссылка_на_задачу)
