### PR TITLE
style: убрал фиксированную ширину в контейнере кнопок

### DIFF
--- a/src/components/ui/announced-play-card/announced-play-card.module.css
+++ b/src/components/ui/announced-play-card/announced-play-card.module.css
@@ -167,8 +167,6 @@
 .buttonContainer {
   @media (max-width: $tablet-portrait) {
     display: flex;
-    width: scale(380px);
-    flex-direction: row;
   }
 }
 


### PR DESCRIPTION
## Описание
Убирает фиксированную ширину в контейнере кнопок

## Ссылка на задачу
[В компоненте announced-play-card убрать фиксированную ширину в контейнере кнопок ](https://www.notion.so/announced-play-card-4fc2c70a8e9c48a19e309907088a0efa)
