### PR TITLE
Bugfix/cicd

### DIFF
--- a/infra_deploy/stage/lubimovka-frontend.service
+++ b/infra_deploy/stage/lubimovka-frontend.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
-TimeoutStartSec=600
+TimeoutStartSec=1200
 User=root
 
 WorkingDirectory=/LUBIMOVKA/stage/

--- a/infra_deploy/stage/lubimovka-frontend.service
+++ b/infra_deploy/stage/lubimovka-frontend.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 RestartSec=5
+TimeoutStartSec=600
 User=root
 
 WorkingDirectory=/LUBIMOVKA/stage/


### PR DESCRIPTION
Решение проблемы запуска приложения при низкой скорости скачивания docker image. Таймаут у systemd по умолчанию 1,5 минуты, и часто бывает, что образы загружаются из ghcr.io медленно (более 10 минут), что приводило к рестарту службы и скачивание не завершалось до конца. Служба не могла запуститься.

Позже рассмотрю возможность использования slim образов для уменьшения их размера.
lubimovka_backend 1.23GB
lubimovka_frontend 420MB

## Описание
Что делает этот Pull Request?

## Ссылка на задачу
[Название задачи](ссылка_на_задачу)
