### PR TITLE
style: реализовать скролл в фильтрах при переполнении элементов

### DIFF
--- a/src/components/library-pieces-page/index.module.css
+++ b/src/components/library-pieces-page/index.module.css
@@ -70,12 +70,16 @@
 }
 
 .sidebar {
+  @mixin hideScrollbar;
+
   position: sticky;
   z-index: 1;
   top: 0;
   left: auto;
+  max-height: 100vh;
   box-sizing: border-box;
   padding: scale(21px) 0;
+  overflow-y: scroll;
 
   @media (max-width: $tablet-portrait) {
     position: absolute;


### PR DESCRIPTION
## Описание
Исправления замечания от QA: https://www.notion.so/5d6b8df5e8d0466da3d941d0cc84b789
В фильтрах при переполнении элементов программы, отсутствовал скрол.
Для проверки переполнение в программах, дополнительные элементы клонировать вручную.

## Ссылка на задачу
[Добавить скролл в sticky фильтры в библиотеке](https://www.notion.so/sticky-f461ddb95b7f43ed88bb198c9037688a)
