### PR TITLE
style: добавить scroll и sticky для букв в авторах

### DIFF
--- a/src/pages/library/search-result/index.module.css
+++ b/src/pages/library/search-result/index.module.css
@@ -145,7 +145,14 @@
 }
 
 .authorsList {
+  @mixin hideScrollbar;
+
+  position: sticky;
+  top: scale(30px);
+  max-height: scale(calc(100vh - 30px));
   padding: 0;
+  padding-bottom: scale(30px);
   margin: 0;
   list-style: none;
+  overflow-y: auto;
 }


### PR DESCRIPTION
## Описание
Добавляет scroll и sticky для букв в авторах.
Буквы будут фиксироваться, а если их больше высоты экрана, то еще и скролиться.

## Ссылка на задачу
[Добавить sticky для буквы в авторах](https://www.notion.so/sticky-ea8b3cd707774426a8088c63bcd5dece)
