### PR TITLE
Удаление блока Проект открыт к сотрудничеству

### DIFF
--- a/src/components/project-layout/storey/project-layout-storey.module.css
+++ b/src/components/project-layout/storey/project-layout-storey.module.css
@@ -65,23 +65,3 @@
     margin: 0 auto;
   }
 }
-
-.invitation {
-  padding-bottom: scale(169px);
-  margin-top: scale(100px);
-
-  @media (max-width: $tablet-portrait) {
-    padding-bottom: 0;
-  }
-
-  .holder {
-    max-width: scale(516px);
-    margin-right: scale(227px);
-    margin-left: auto;
-
-    @media (max-width: $tablet-portrait) {
-      margin-right: 0;
-      margin-left: 0;
-    }
-  }
-}

--- a/src/components/project-layout/storey/project-layout-storey.tsx
+++ b/src/components/project-layout/storey/project-layout-storey.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames/bind';
 import styles from './project-layout-storey.module.css';
 
 interface IProjectLayoutStoreyProps {
-  type?: 'description' | 'videos' | 'photos' | 'plays' | 'performances' | 'persons' | 'text' | 'invitation',
+  type?: 'description' | 'videos' | 'photos' | 'plays' | 'performances' | 'persons' | 'text',
 }
 
 const cx = classNames.bind(styles);

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -4,7 +4,6 @@ import { PageBreadcrumbs } from 'components/page';
 import { ProjectLayout } from 'components/project-layout';
 import { Breadcrumb } from 'components/breadcrumb';
 import { ProjectHeadline } from 'components/project-headline';
-import { CallToEmail } from 'components/call-to-email';
 import { ConstructorContent } from 'components/constructor-content';
 import { fetcher } from 'shared/fetcher';
 
@@ -41,15 +40,7 @@ const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>) 
           // @ts-expect-error
           blocks={contents}
         />
-        <ProjectLayout.Storey type="invitation">
-          <CallToEmail
-            type="project"
-            title="Проект открыт к сотрудничеству"
-            description="Мы находимся в постоянном поиске режиссёров и актеров, заинтересованных в постановке читок."
-            callToActionText="Пишите на"
-            email="hello@lubimovka.ru"
-          />
-        </ProjectLayout.Storey>
+        <ProjectLayout.Storey type="invitation"/>
       </ProjectLayout>
     </AppLayout>
   );

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -40,7 +40,6 @@ const Project = (props: InferGetServerSidePropsType<typeof getServerSideProps>) 
           // @ts-expect-error
           blocks={contents}
         />
-        <ProjectLayout.Storey type="invitation"/>
       </ProjectLayout>
     </AppLayout>
   );


### PR DESCRIPTION
## Описание
Удален блок «Проект открыт к сотрудничеству»

## Ссылка на задачу
[Убрать блок «Проект открыт к сотрудничеству»](https://www.notion.so/790ed8be65ce47aeaa0969257bc3951e)

## Комментарии
Я не стала удалять сам project-layout-storey_wrapper, чтобы сохранить отступы (предыдущий блок переиспользуется во многих других местах) и на случай проектов, в котором этот блок может понадобиться.
