### PR TITLE
Добавление мета-информации на страницы сайта

### DIFF
--- a/src/pages/about-us/ideology/index.tsx
+++ b/src/pages/about-us/ideology/index.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from 'next';
-import Head from 'next/head';
+import { SEO } from 'components/seo';
 
 import { AppLayout } from 'components/app-layout';
 import IdeologyPage from 'components/ideology-page';
@@ -8,11 +8,9 @@ import textData from './assets/mock-data.json';
 
 const Ideology: NextPage = () => (
   <AppLayout>
-    <Head>
-      <title>
-        Идеология
-      </title>
-    </Head>
+    <SEO
+      title="Идеология"
+    />
     <IdeologyPage data={textData}/>
   </AppLayout>
 );

--- a/src/pages/about-us/team/index.tsx
+++ b/src/pages/about-us/team/index.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import Head from 'next/head';
 import Error from 'next/error';
+import { SEO } from 'components/seo';
 import { useRouter } from 'next/router';
 
 import { AppLayout } from 'components/app-layout';
@@ -26,11 +26,9 @@ const Team = ({ errorCode, team, volunteers }: InferGetServerSidePropsType<typeo
 
   return (
     <AppLayout>
-      <Head>
-        <title>
-          {'Организаторы'}
-        </title>
-      </Head>
+      <SEO
+        title="Организаторы"
+      />
       <main>
         <TeamPage team={team} volunteers={volunteers} queryYear={queryYear}/>
       </main>

--- a/src/pages/about-us/trustees/index.tsx
+++ b/src/pages/about-us/trustees/index.tsx
@@ -1,6 +1,7 @@
 import { AppLayout } from 'components/app-layout';
 import TrusteesSection from 'components/trustees-section/trustees-section';
 import PersonsList from 'components/persons-list/persons-list';
+import { SEO } from 'components/seo';
 import { usePersistentData } from 'providers/persistent-data-provider';
 import { fetcher } from 'services/fetcher';
 
@@ -17,6 +18,9 @@ const Trustees = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
 
   return (
     <AppLayout>
+      <SEO
+        title="Попечители"
+      />
       <main>
         <TrusteesSection
           title="Попечители фестиваля"
@@ -63,4 +67,3 @@ export const getServerSideProps: GetServerSideProps<ITrusteesProps> = async () =
 };
 
 export default Trustees;
-

--- a/src/pages/blog/blog.tsx
+++ b/src/pages/blog/blog.tsx
@@ -12,6 +12,7 @@ import { BlogLayout } from 'components/blog-layout';
 import { PageTitle } from 'components/page-title';
 import { Spinner } from 'components/spinner';
 import { CallToEmail } from 'components/call-to-email';
+import { SEO } from 'components/seo';
 import { useBlog } from 'providers/blog-provider';
 import { usePersistentData } from 'providers/persistent-data-provider';
 import { useIntersection } from 'shared/hooks/use-intersection';
@@ -94,6 +95,9 @@ const Blog = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => 
 
   return (
     <AppLayout>
+      <SEO
+        title="Блог"
+      />
       <BlogLayout>
         <BlogLayout.Title>
           <PageTitle>

--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -9,6 +9,7 @@ import TextInput from 'components/ui/text-input/text-input';
 import TextArea from 'components/ui/text-area';
 import { Button } from 'components/ui/button';
 import { CallToEmail } from 'components/call-to-email';
+import { SEO } from 'components/seo';
 import { usePersistentData } from 'providers/persistent-data-provider';
 import { fetcher } from 'services/fetcher';
 import { validEmailRegexp } from 'shared/constants/regexps';
@@ -192,6 +193,9 @@ const Contacts: NextPage = () => {
 
   return (
     <AppLayout>
+      <SEO
+        title="Контакты"
+      />
       <ContactsLayout>
         <ContactsLayout.Column>
           <ContactsLayout.Title>

--- a/src/pages/donation/index.tsx
+++ b/src/pages/donation/index.tsx
@@ -11,7 +11,7 @@ import mockData from './assets/mock-donation-data.json';
 const Donation: NextPage = () => (
   <AppLayout>
     <SEO
-      title={mockData.title}
+      title="Поддержать фестиваль"
     />
     <main>
       <DonationPageTitle

--- a/src/pages/donation/index.tsx
+++ b/src/pages/donation/index.tsx
@@ -1,20 +1,18 @@
 import { NextPage } from 'next';
-import Head from 'next/head';
 
 import { AppLayout } from 'components/app-layout';
 import { DonationPageTitle } from 'components/donation-page/donationPageTitle';
 import { Opportunities } from 'components/donation-page/opportunities';
 import { Report } from 'components/donation-page/report';
+import { SEO } from 'components/seo';
 
 import mockData from './assets/mock-donation-data.json';
 
 const Donation: NextPage = () => (
   <AppLayout>
-    <Head>
-      <title>
-        {mockData.title}
-      </title>
-    </Head>
+    <SEO
+      title={mockData.title}
+    />
     <main>
       <DonationPageTitle
         header={mockData.donationPageTitle.header}

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -7,6 +7,7 @@ import { AfishaProvider } from 'components/afisha-page/afisha-provider';
 import { fetchEvents, fetchInfo } from 'components/afisha-page/utils/fetchData';
 import { AfishaEvents, AfishaInfo } from 'shared/types';
 import { RegularEvents } from 'components/afisha-page/regular-events';
+import { SEO } from 'components/seo';
 
 interface IProps {
   info: AfishaInfo;
@@ -21,6 +22,9 @@ const Events = (props: InferGetServerSidePropsType<typeof getServerSideProps>) =
 
   return (
     <AppLayout>
+      <SEO
+        title="Афиша фестиваля"
+      />
       <main>
         <AfishaTitle
           {...info}

--- a/src/pages/form/form.tsx
+++ b/src/pages/form/form.tsx
@@ -7,6 +7,7 @@ import { AppLayout } from 'components/app-layout';
 import PlayProposalLayout from 'components/play-proposal-layout';
 import PlayProposalTitle from 'components/play-proposal-title';
 import { ParticipationForm } from 'components/participation-form';
+import { SEO } from 'components/seo';
 import {
   validYearRegexp,
   validEmailRegexp,
@@ -271,6 +272,9 @@ const Participation: NextPage = () => {
 
   return (
     <AppLayout>
+      <SEO
+        title="Приём пьес"
+      />
       <PlayProposalLayout>
         <PlayProposalLayout.Image>
           <Image

--- a/src/pages/form/form.tsx
+++ b/src/pages/form/form.tsx
@@ -273,7 +273,7 @@ const Participation: NextPage = () => {
   return (
     <AppLayout>
       <SEO
-        title="Приём пьес"
+        title="Подать пьесу"
       />
       <PlayProposalLayout>
         <PlayProposalLayout.Image>

--- a/src/pages/form/success.tsx
+++ b/src/pages/form/success.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { PageTransition } from 'components/page-transition';
 import { PlayProposalSuccessLayout } from 'components/play-proposal-success-layout';
 import { AppLayout } from 'components/app-layout';
+import { SEO } from 'components/seo';
 
 interface IPlayProposalSuccessProps {
   referer: string | null,
@@ -13,6 +14,9 @@ const PlayProposalSuccess = ({ referer }: InferGetServerSidePropsType<typeof get
       {referer && (
         <PageTransition type="rightToLeft">
           <AppLayout>
+            <SEO
+              title="Пьеса успешно отправлена"
+            />
             <PlayProposalSuccessLayout/>
           </AppLayout>
         </PageTransition>

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 
 import { AppLayout } from 'components/app-layout/index';
 import { HistoryPage } from 'components/history-page';
+import { SEO } from 'components/seo';
 import { fetcher } from 'services/fetcher';
 import { Festival, Years, PlayFilters } from 'api-typings';
 
@@ -11,6 +12,9 @@ const History = (props: InferGetServerSidePropsType<typeof getServerSideProps>) 
   } = props;
   return (
     <AppLayout>
+      <SEO
+        title="История фестиваля"
+      />
       <HistoryPage years={years} titleCounts={titleCounts} playFilters={playFilters}/>
     </AppLayout>
   );

--- a/src/pages/library/authors.tsx
+++ b/src/pages/library/authors.tsx
@@ -1,10 +1,10 @@
 import Error from 'next/error';
-import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import { AppLayout } from 'components/app-layout';
 import AuthorsPage from 'components/library-authors-page';
+import { SEO } from 'components/seo';
 import { fetcher } from 'services/fetcher';
 
 import type { PaginatedAuthorListList, AuthorList, AuthorLetters } from 'api-typings';
@@ -48,11 +48,9 @@ const Authors = ({ errorCode, authors, letters }: InferGetServerSidePropsType<ty
 
   return (
     <AppLayout>
-      <Head>
-        <title>
-          Авторы
-        </title>
-      </Head>
+      <SEO
+        title="Библиотека - авторы"
+      />
       <AuthorsPage letters={letters} authors={a} isLoading={isLoading} onLetterChange={()=>setIsLoading(true)}/>
     </AppLayout>
   );

--- a/src/pages/library/authors.tsx
+++ b/src/pages/library/authors.tsx
@@ -49,7 +49,7 @@ const Authors = ({ errorCode, authors, letters }: InferGetServerSidePropsType<ty
   return (
     <AppLayout>
       <SEO
-        title="Библиотека - авторы"
+        title="Авторы"
       />
       <AuthorsPage letters={letters} authors={a} isLoading={isLoading} onLetterChange={()=>setIsLoading(true)}/>
     </AppLayout>

--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -1,10 +1,10 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useEffect, useState, useReducer } from 'react';
 import Error from 'next/error';
-import Head from 'next/head';
 
 import { AppLayout } from 'components/app-layout';
 import LibraryPage from 'components/library-pieces-page';
+import { SEO } from 'components/seo';
 import { fetcher } from 'services/fetcher';
 import { PaginatedPlayList, Play } from 'api-typings';
 import reducer from 'components/library-filter/library-filter-reducer';
@@ -67,11 +67,9 @@ const Library = ({ errorCode, pieces, years, programs }:
   return (
     <LibraryFiltersProvider value={filterState}>
       <AppLayout>
-        <Head>
-          <title>
-            Библиотека
-          </title>
-        </Head>
+        <SEO
+          title="Библиотека - пьесы"
+        />
         <LibraryPage
           isLoading={isLoading}
           items={piecesState}

--- a/src/pages/library/search-no-result/index.tsx
+++ b/src/pages/library/search-no-result/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 
 import * as breakpoints from 'shared/breakpoints.js';
 import { AppLayout } from 'components/app-layout';
+import { SEO } from 'components/seo';
 import { Button } from 'components/ui/button';
 import { useMediaQuery } from 'shared/hooks/use-media-query';
 import LibraryForm from 'components/library-form/library-form';
@@ -36,6 +37,9 @@ const SearchResult: NextPage = () => {
   return (
     <div className={style.pageWrapper}>
       <AppLayout>
+        <SEO
+          title="Ничего не найдено в библиотеке"
+        />
         <main className ={style.page}>
           <div className={style.buttonWrapper}>
             {isMobile !== null && (

--- a/src/pages/library/search-no-result/index.tsx
+++ b/src/pages/library/search-no-result/index.tsx
@@ -38,7 +38,7 @@ const SearchResult: NextPage = () => {
     <div className={style.pageWrapper}>
       <AppLayout>
         <SEO
-          title="Ничего не найдено в библиотеке"
+          title="Ничего не найдено"
         />
         <main className ={style.page}>
           <div className={style.buttonWrapper}>

--- a/src/pages/library/search-result/index.tsx
+++ b/src/pages/library/search-result/index.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 
 import * as breakpoints from 'shared/breakpoints.js';
 import { AppLayout } from 'components/app-layout';
+import { SEO } from 'components/seo';
 import { Button } from 'components/ui/button';
 import LibraryForm from 'components/library-form/library-form';
 import { BasicPlayCard } from 'components/ui/basic-play-card';
@@ -106,6 +107,9 @@ const SearchResult: NextPage = ( { data }:InferGetServerSidePropsType<typeof get
   return (
     <div className={style.pageWrapper}>
       <AppLayout>
+        <SEO
+          title="Результаты поиска по библиотеке"
+        />
         <main className ={style.page}>
           <div className={style.buttonWrapper}>
             {isMobile !== null && (

--- a/src/pages/library/search-result/index.tsx
+++ b/src/pages/library/search-result/index.tsx
@@ -108,7 +108,7 @@ const SearchResult: NextPage = ( { data }:InferGetServerSidePropsType<typeof get
     <div className={style.pageWrapper}>
       <AppLayout>
         <SEO
-          title="Результаты поиска по библиотеке"
+          title="Результаты поиска"
         />
         <main className ={style.page}>
           <div className={style.buttonWrapper}>

--- a/src/pages/news/news.tsx
+++ b/src/pages/news/news.tsx
@@ -9,6 +9,7 @@ import { Filter } from 'components/filter';
 import { Select } from 'components/select';
 import { NewsList } from 'components/news-list';
 import { NewsCard } from 'components/news-card';
+import { SEO } from 'components/seo';
 import { useNews } from 'providers/news-provider';
 import { useIntersection } from 'shared/hooks/use-intersection';
 import { fetcher } from 'services/fetcher';
@@ -89,6 +90,9 @@ const News = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => 
 
   return (
     <AppLayout>
+      <SEO
+        title="Новости"
+      />
       <NewsLayout>
         <PageTitle className={cx('title')}>
           Новости

--- a/src/pages/performances/[id].tsx
+++ b/src/pages/performances/[id].tsx
@@ -16,6 +16,7 @@ import { PerformanceEventList } from 'components/performance-event-list';
 import { ReviewCarousel } from 'components/review-carousel';
 import { MediaReviewCard } from 'components/media-review-card';
 import { ReviewCard } from 'components/review-card';
+import { SEO } from 'components/seo';
 import { format } from 'shared/helpers/format-date';
 import { fetcher } from 'services/fetcher';
 import { notFoundResult } from 'shared/constants/server-side-props';
@@ -54,6 +55,10 @@ const Performance = (props: InferGetServerSidePropsType<typeof getServerSideProp
 
   return (
     <AppLayout>
+      <SEO
+        title={title}
+        description={description}
+      />
       <PerformanceLayout>
         <PerformanceHeadline
           className={cx('headline')}

--- a/src/pages/press-releases/[year].tsx
+++ b/src/pages/press-releases/[year].tsx
@@ -8,6 +8,7 @@ import { PressReleaseLayout } from 'components/press-release-layout';
 import { PageTitle } from 'components/page-title';
 import { Filter } from 'components/filter';
 import { Select } from 'components/select';
+import { SEO } from 'components/seo';
 import { Button } from 'components/ui/button2';
 import { HTMLMarkup } from 'components/html-markup';
 import { Icon } from 'components/ui/icon';
@@ -62,6 +63,9 @@ const PressReleases = (props: InferGetServerSidePropsType<typeof getServerSidePr
 
   return (
     <AppLayout>
+      <SEO
+        title="Пресс-релизы"
+      />
       <ForPressHero data={{
         forPressHeroTitle: {
           title: 'Для прессы',

--- a/src/pages/projects/projects.tsx
+++ b/src/pages/projects/projects.tsx
@@ -6,6 +6,7 @@ import { ProjectsLayout } from 'components/projects-layout';
 import { ProjectCardList } from 'components/project-card-list';
 import { ProjectCard } from 'components/ui/project-card';
 import { PageTitle } from 'components/page-title';
+import { SEO } from 'components/seo';
 import { fetcher } from 'services/fetcher';
 import { PaginatedProjectListList, ProjectList } from 'api-typings';
 import { isEven } from 'shared/helpers/is-even';
@@ -24,6 +25,9 @@ const Projects = ({ errorCode, projects }: InferGetServerSidePropsType<typeof ge
 
   return (
     <AppLayout>
+      <SEO
+        title="Проекты"
+      />
       <ProjectsLayout>
         <ProjectsLayout.Headline>
           <PageTitle>
@@ -83,4 +87,3 @@ export const getServerSideProps: GetServerSideProps<IProjectsProps> = async () =
 };
 
 export default Projects;
-


### PR DESCRIPTION
## Описание
Добавляет заголовки страниц и прочую мета-информацию (где это возможно) на всех страницах сайта.

## Ссылка на задачу
[Добавить заголовки страниц.](https://www.notion.so/f361f7c8bd7f492eb2c0c94ff29b0db4)
