### PR TITLE
fix(library-authors-page): исправить затенение ссылок 'нависающим' ко…

### DIFF
--- a/src/components/library-authors-page/index.module.css
+++ b/src/components/library-authors-page/index.module.css
@@ -49,13 +49,11 @@
   z-index: 1;
   top: 0;
   left: 0;
-  height: calc(100% - 270px);
 
   @media (max-width: $tablet-portrait) {
     top: 47px;
     left: 0;
     width: 100%;
-    height: calc(100% - 166px);
   }
 }
 


### PR DESCRIPTION
## Описание
Все ссылки до последней затенялись "нависающим" компонентом. Исправил уменьшением высоты этого компонента. Для трёх авторов (макс. возм. замоканный случай) всё работает, вёрстка не поломалась.

Смысл правила `height` для элемента `.menuWrap` понять не удалось. После исправления, проблема пропала и не воспроизводилась. Однако, тестерам, всё же стоит ещё раз посмотреть.

## Ссылка на задачу
[Моб. Библиотека, Авторы. При клике на авторов, кроме последнего в списке, не открывается страница автора](https://www.notion.so/0e0a12ebae98440aacddc972c7e44beb)
