### PR TITLE
Замена ссылки и текста на странице "История"

### DIFF
--- a/src/components/history-page/itself/history-itself.tsx
+++ b/src/components/history-page/itself/history-itself.tsx
@@ -59,11 +59,11 @@ export const HistoryItself: FC<IHistoryItself>= ({ data }) => {
       </p>
       <p className={style.text2}>
         Более подробно об истории, знаковых пьесах, памятных событиях фестиваля можно прочитать в специальном номере журнала «Театр.» (№48), который вышел в 2022 году. Это первая за тридцать лет существования «Любимовки» попытка сохранить всю хронологию и программы, увидеть весь объём фестиваля как явления культуры.
-        Приобрести журнал можно
+        Прочитать журнал можно
         {' '}
         <a
           className={style.link}
-          href="http://oteatre.info/gde-kupit"
+          href="https://lubimovka.art/files/history/Theatre_48.pdf"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
## Описание
- Исправлен текст в последней фразе на странице 'История'. 
- Для ссылки "здесь" поправлен атрибут href.

[Ссылка на задачу](https://www.notion.so/35faea77a71242deba9633f091f2ae64)

