### PR TITLE
Скрытие кнопок подачи пьесы, если прием пьес закрыт

### DIFF
--- a/src/components/404/NotFoundError.tsx
+++ b/src/components/404/NotFoundError.tsx
@@ -7,8 +7,11 @@ import classes from './NotFoundError.module.css';
 import { useMediaQuery } from 'shared/hooks/use-media-query';
 import * as breakpoints from 'shared/breakpoints';
 import { Button } from 'components/ui/button';
+import { usePersistentData } from 'providers/persistent-data-provider';
+import { participationFormPath } from 'shared/constants/participation-form-path';
 
 export default function NotFoundError() {
+  const { settings } = usePersistentData();
   const isMobile = useMediaQuery(`(max-width: ${breakpoints['tablet-portrait']})`);
 
   return (
@@ -44,18 +47,20 @@ export default function NotFoundError() {
               label={'На главную'}
             />
           </li>
-          <li className={classes.listItem}>
-            <Button
-              border="bottomLeft"
-              isLink
-              size={'s'}
-              className={classes.link}
-              iconPlace={'left'}
-              icon={'arrow-right'}
-              href={'/form'}
-              label={'Подать пьесу'}
-            />
-          </li>
+          {settings?.canProposePlay && (
+            <li className={classes.listItem}>
+              <Button
+                border="bottomLeft"
+                isLink
+                size={'s'}
+                className={classes.link}
+                iconPlace={'left'}
+                icon={'arrow-right'}
+                href={participationFormPath}
+                label={'Подать пьесу'}
+              />
+            </li>
+          )}
           <li className={classes.listItem}>
             <Button
               border="bottomLeft"

--- a/src/components/app-layout/app-layout.tsx
+++ b/src/components/app-layout/app-layout.tsx
@@ -178,10 +178,12 @@ export const AppLayout = (props: AppLayoutProps) => {
               </OverlayNav.Menu>
               <OverlayNav.Actions>
                 <Menu type="overlay-actions">
-                  <Menu.Item href={participationFormPath}>
-                    Подать пьесу
-                    <Icon glyph="arrow-right"/>
-                  </Menu.Item>
+                  {settings?.canProposePlay && (
+                    <Menu.Item href={participationFormPath}>
+                      Подать пьесу
+                      <Icon glyph="arrow-right"/>
+                    </Menu.Item>
+                  )}
                   <Menu.Item href={donationPath}>
                     Поддержать
                     <Icon glyph="arrow-right"/>


### PR DESCRIPTION
## Описание
Добавлена зависимость от статуса фестиваля для кнопки "Подать пьесу" на страницах 404 и в мобильном меню (layout-menu)

## Ссылка на задачу
[Важно! Кнопка Подать пьесу на странице 404 не нужна в то время, когда прием пьес закрыт](https://www.notion.so/404-2f93524d060e45708f81fa34f5383eee)
