### PR TITLE
Приведение карточки партнера к дизайну

### DIFF
--- a/src/components/app-layout/app-layout.tsx
+++ b/src/components/app-layout/app-layout.tsx
@@ -110,14 +110,17 @@ export const AppLayout = (props: AppLayoutProps) => {
       {children}
       <Page.Footer>
         <Footer privacyPolicyUrl={settings?.privacyPolicyUrl}>
-          {!hiddenPartners && generalPartners && generalPartners.length > 0 && (
+          {!hiddenPartners && generalPartners && generalPartners?.length > 0 && (
             <Footer.Partners>
               <PartnerList size="s">
                 {generalPartners.map((partner) => (
                   <PartnerList.Item key={partner.name}>
                     <PartnerCard
+                      variant="compact"
+                      titleTag="p"
                       logo={partner.logo}
                       name={partner.name}
+                      description={partner.description}
                       url={partner.url}
                     />
                   </PartnerList.Item>

--- a/src/components/partner-card/partner-card.module.css
+++ b/src/components/partner-card/partner-card.module.css
@@ -7,25 +7,37 @@
   padding-bottom: 35%;
 }
 
+.link {
+  color: inherit;
+  text-decoration: none;
+
+  &::after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    content: '';
+  }
+}
+
 .title {
+  @mixin visually-hidden;
+}
+
+.description {
   @mixin text;
 
   display: block;
-  margin-top: 16px;
+  margin: 10px 0 0;
   font-size: 14px;
   line-height: 20px;
   text-align: center;
 }
 
-.link {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
-.hidden-text {
-  @mixin visually-hidden;
+.compact {
+  .description {
+    @mixin visually-hidden;
+  }
 }

--- a/src/components/partner-card/partner-card.tsx
+++ b/src/components/partner-card/partner-card.tsx
@@ -7,16 +7,20 @@ import type { VFC } from 'react';
 import styles from './partner-card.module.css';
 
 interface PartnerCardProps {
-  name?: string
+  variant?: 'regular' | 'compact'
+  titleTag?: 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  name: string
   description?: string
   logo: Url
-  url?: Url
+  url: Url
 }
 
 const cx = classNames.bind(styles);
 
 const PartnerCard: VFC<PartnerCardProps> = (props) => {
   const {
+    variant = 'regular',
+    titleTag: TitleTag = 'h3',
     name,
     description,
     logo,
@@ -24,7 +28,7 @@ const PartnerCard: VFC<PartnerCardProps> = (props) => {
   } = props;
 
   return (
-    <div className={cx('root')}>
+    <div className={cx('root', [variant])}>
       <div className={cx('logo-canvas')}>
         <Image
           className={cx('logo')}
@@ -34,23 +38,21 @@ const PartnerCard: VFC<PartnerCardProps> = (props) => {
           objectFit="contain"
         />
       </div>
-      {description && (
-        <span className={cx('description')}>
-          {description}
-        </span>
-      )}
-      {url && (
-        <a
-          className={cx('link')}
-          href={url}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <span className={cx('hidden-text')}>
-            {name}
-          </span>
-        </a>
-      )}
+      <a
+        className={cx('link')}
+        href={url}
+        target="_blank"
+        rel="noreferrer"
+      >
+        <TitleTag className={cx('title')}>
+          {name}
+        </TitleTag>
+        {description && (
+          <p className={cx('description')}>
+            {description}
+          </p>
+        )}
+      </a>
     </div>
   );
 };

--- a/src/core/partner/types.ts
+++ b/src/core/partner/types.ts
@@ -4,7 +4,8 @@ import { PartnerType } from './constants';
 
 export type Partner = {
   name: string,
+  description?: string,
   logo: Url,
   type: keyof typeof PartnerType,
-  url?: Url,
+  url: Url,
 }

--- a/src/pages/main/main.tsx
+++ b/src/pages/main/main.tsx
@@ -239,8 +239,10 @@ const Main = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => 
                 {partners[group].map((partner) => (
                   <PartnerList.Item key={partner.name}>
                     <PartnerCard
+                      variant="regular"
                       logo={partner.logo}
                       name={partner.name}
+                      description={partner.description}
                       url={partner.url}
                     />
                   </PartnerList.Item>

--- a/src/services/api/partners.ts
+++ b/src/services/api/partners.ts
@@ -16,6 +16,7 @@ export function getPartners({ onlyGeneral = false }  = {}) {
 function mapDTOToPartner(dto: PartnerDTO[]): Partner[] {
   return dto.map((partner) => ({
     name: partner.name,
+    description: partner.description,
     logo: partner.image,
     type: partner.type,
     url: partner.url,

--- a/src/services/api/partners.ts
+++ b/src/services/api/partners.ts
@@ -7,7 +7,7 @@ import type { Partner } from 'core/partner';
 
 export function getPartners({ onlyGeneral = false }  = {}) {
   const params = objectToQueryString({
-    is_general: onlyGeneral,
+    ...onlyGeneral && { is_general: true },
   });
 
   return fetcher<PartnerDTO[]>(`/info/partners/${params}`).then(mapDTOToPartner);


### PR DESCRIPTION
## Описание
- Добавлены отсутствующие стили для класса description
- Добавлено свойство description в type и api для партнеров
- Исправлен баг с выводом на главной странице всех партнеров (вместо всех отображались только партнеры с флагом is_general: false)
- Описание для партнера выводится только при его наличии, а так же если в карточке есть пропс description

## Ссылка на задачу
[Для Партнеров не отражаются наименования под логотипом](https://www.notion.so/8edab21581424af79446f4b8ff75f267)
