### PR TITLE
Исправить продолжительность на странице спектакля

### DIFF
--- a/src/pages/performances/[id].tsx
+++ b/src/pages/performances/[id].tsx
@@ -230,7 +230,15 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       video: performanceResponse.video,
       text: performanceResponse.text,
       ageRestriction: performanceResponse.age_limit,
-      duration: toDuration(performanceResponse.duration),
+      duration: performanceResponse.duration > 0
+        ? formatDuration({
+          hours: Math.floor(performanceResponse.duration / 3600),
+          minutes: Math.floor(performanceResponse.duration % 3600 / 60),
+        },
+        {
+          locale: ru
+        })
+        : undefined,
       events: toEvents(performanceResponse.events),
       // TODO: сейчас в ответе API возвращаются списки отзывов с пагинацией, которая фронтенду не нужна, нужно обсудить с бекендерами
       mediaReviews: mediaReviewsResponse.results
@@ -266,10 +274,3 @@ function toReviews(reviews: PerformanceReview[]) {
     ...url ? { href: url } : {}
   }));
 };
-
-function toDuration(d?:number) {
-  if(d) {
-    return formatDuration({ hours: Math.floor(d / 3600), minutes: Math.floor(d % 3600 / 60) }, { locale: ru });
-  }
-  return undefined;
-}

--- a/src/pages/performances/[id].tsx
+++ b/src/pages/performances/[id].tsx
@@ -21,6 +21,8 @@ import { format } from 'shared/helpers/format-date';
 import { InternalServerError } from 'shared/helpers/internal-server-error';
 import { fetcher } from 'services/fetcher';
 import { notFoundResult } from 'shared/constants/server-side-props';
+import { formatDuration } from 'date-fns';
+import ru from 'date-fns/locale/ru';
 
 import type { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import type {
@@ -228,7 +230,7 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       video: performanceResponse.video,
       text: performanceResponse.text,
       ageRestriction: performanceResponse.age_limit,
-      duration: performanceResponse.duration,
+      duration: toDuration(performanceResponse.duration),
       events: toEvents(performanceResponse.events),
       // TODO: сейчас в ответе API возвращаются списки отзывов с пагинацией, которая фронтенду не нужна, нужно обсудить с бекендерами
       mediaReviews: mediaReviewsResponse.results
@@ -264,3 +266,10 @@ function toReviews(reviews: PerformanceReview[]) {
     ...url ? { href: url } : {}
   }));
 };
+
+function toDuration(d?:number) {
+  if(d) {
+    return formatDuration({ hours: Math.floor(d / 3600), minutes: Math.floor(d % 3600 / 60) }, { locale: ru });
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Описание
В соответствии с новым форматом продолжительности пьесы (по нашей просьбе бэкендеры изменили отдачу времени пьесы в секундах) добавлен вывод даты в уже форматированном виде при помощи date-fns для чего я сделал небольшую функцию, которая проверяет наличие этого времени и в случае успеха отдает продолжительность в нужном формате

## Ссылка на задачу
[Исправить продолжительность на странице спектакля](https://www.notion.so/276d6d3f95a14d3d8a8a290bf97b41f6)
