### PR TITLE
Добавление заголовка галереи спектакля

### DIFF
--- a/src/components/image-gallery/image-gallery.module.css
+++ b/src/components/image-gallery/image-gallery.module.css
@@ -12,6 +12,21 @@
   }
 }
 
+.title {
+  @mixin headline;
+  @mixin headline4;
+
+  max-width: 568px;
+  margin: 0 auto 40px 362px;
+
+  @media (max-width: $tablet-portrait) {
+    @mixin headline6;
+
+    max-width: 369px;
+    margin: 0 22px 34px;
+  }
+}
+
 .item {
   position: relative;
   overflow: hidden;

--- a/src/components/image-gallery/image-gallery.tsx
+++ b/src/components/image-gallery/image-gallery.tsx
@@ -16,12 +16,13 @@ type GalleryImage = {
 }
 
 interface ImageGalleryProps {
+  title?: string
   items: GalleryImage[]
   className?: string
 }
 
 export const ImageGallery: React.VFC<ImageGalleryProps> = (props) => {
-  const { className, items } = props;
+  const { className, title, items } = props;
   const [fullscreenMode, setFullscreenMode] = useState(false);
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
 
@@ -34,6 +35,11 @@ export const ImageGallery: React.VFC<ImageGalleryProps> = (props) => {
 
   return (
     <div>
+      {title && (
+        <h2 className={cx('title')}>
+          {title}
+        </h2>
+      )}
       <ul className={cx('list', className)}>
         {items.map(({ url, description = '' }, index) => (
           <li

--- a/src/pages/performances/[id].tsx
+++ b/src/pages/performances/[id].tsx
@@ -45,6 +45,7 @@ const Performance = (props: InferGetServerSidePropsType<typeof getServerSideProp
     play,
     team,
     gallery_images,
+    gallery_title,
     main_image,
     bottom_image,
     video,
@@ -137,6 +138,7 @@ const Performance = (props: InferGetServerSidePropsType<typeof getServerSideProp
         </PerformanceLayout.Content>
         <PerformanceLayout.Gallery>
           <ImageGallery
+            title={gallery_title}
             items={gallery_images.map(({ url }) => ({
               url,
             }))}
@@ -225,6 +227,7 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       play: performanceResponse.play,
       team: performanceResponse.team,
       gallery_images: performanceResponse.gallery_images,
+      gallery_title: performanceResponse.gallery_title,
       main_image: performanceResponse.main_image,
       bottom_image: performanceResponse.bottom_image,
       video: performanceResponse.video,


### PR DESCRIPTION
## Описание
На странице о спектакле отображается заголовок галереи если он есть

## Ссылка на задачу
[Исправить заголовок блока изображений конструктора](https://www.notion.so/4b33530b19c44b1aa1151e3bd16a486a?v=84023778e1024506b75f0af4321bfba2&p=73d98cef13a645eaa0bd33a0114bc788&pm=s)
