### PR TITLE
fix: замена ссылки на странице История

### DIFF
--- a/src/components/history-page/itself/history-itself.tsx
+++ b/src/components/history-page/itself/history-itself.tsx
@@ -64,7 +64,7 @@ export const HistoryItself: FC<IHistoryItself>= ({ data }) => {
         {' '}
         <a
           className={style.link}
-          href="https://lubimovka.art/files/history/Theatre_48.pdf"
+          href="https://lubimovka.art/media/filer_public/9d/7b/9d7b8913-b0fe-4adf-9abf-b2e6de119b98/theatre_48.pdf"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
## Описание
Заменяет ссылку на журнал на странице "История"

## Ссылка на задачу
[Заменить ссылку на странице «История»](https://www.notion.so/ab25c69830d44983ae08be9e12cfc7c2)

## Скриншоты
![image](https://user-images.githubusercontent.com/64607926/220721644-c2b8d1d7-a092-4d78-9c6a-22b8dfd79efa.png)
![image](https://user-images.githubusercontent.com/64607926/220721802-02151df5-89a8-4d3e-b70a-23680c37836d.png)
