### PR TITLE
fix: hid routes and nav links to team and sponsors

### DIFF
--- a/src/pages/about-us/sponsors/index.tsx
+++ b/src/pages/about-us/sponsors/index.tsx
@@ -1,49 +1,64 @@
-import { AppLayout } from 'components/app-layout';
-import { AboutUsLayout } from 'components/about-us-layout';
-import SponsorsSection from 'components/sponsors-section/sponsors-section';
-import PersonsList from 'components/persons-list/persons-list';
-import { SEO } from 'components/seo';
-import { usePersistentData } from 'providers/persistent-data-provider';
-import { fetcher } from 'services/fetcher';
+// import { AppLayout } from 'components/app-layout';
+// import { AboutUsLayout } from 'components/about-us-layout';
+// import SponsorsSection from 'components/sponsors-section/sponsors-section';
+// import PersonsList from 'components/persons-list/persons-list';
+// import { SEO } from 'components/seo';
+// import { usePersistentData } from 'providers/persistent-data-provider';
+// import { fetcher } from 'services/fetcher';
 
-import type { InferGetServerSidePropsType } from 'next';
-import type { Sponsor } from 'api-typings';
+// import type { InferGetServerSidePropsType } from 'next';
+// import type { Sponsor } from 'api-typings';
 
-const Sponsors = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const { sponsors } = props;
-  const { settings } = usePersistentData();
+// const Sponsors = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+//   const { sponsors } = props;
+//   const { settings } = usePersistentData();
 
-  return (
-    <AppLayout>
-      <SEO title="Попечители"/>
-      <AboutUsLayout>
-        <SponsorsSection
-          title="Попечители фестиваля"
-          description="Здесь представлены частные лица и организации, которые помогают Любимовке на постоянной и безвозмездной основе."
-          callToEmail="Если вы хотите стать попечителем фестиваля, напишите нам на "
-          callToEmailAddress={settings?.emailAddresses.sponsorship}
-        >
-          <PersonsList persons={sponsors}/>
-        </SponsorsSection>
-      </AboutUsLayout>
-    </AppLayout>
-  );
-};
+//   return (
+//     <AppLayout>
+//       <SEO title="Попечители"/>
+//       <AboutUsLayout>
+//         <SponsorsSection
+//           title="Попечители фестиваля"
+//           description="Здесь представлены частные лица и организации, которые помогают Любимовке на постоянной и безвозмездной основе."
+//           callToEmail="Если вы хотите стать попечителем фестиваля, напишите нам на "
+//           callToEmailAddress={settings?.emailAddresses.sponsorship}
+//         >
+//           <PersonsList persons={sponsors}/>
+//         </SponsorsSection>
+//       </AboutUsLayout>
+//     </AppLayout>
+//   );
+// };
 
-export const getServerSideProps = async () => {
-  let sponsors;
+// export const getServerSideProps = async () => {
+//   let sponsors;
 
-  try {
-    sponsors = await fetcher<Sponsor[]>('/info/about-festival/sponsors/');
-  } catch (error) {
-    throw error;
-  }
+//   try {
+//     sponsors = await fetcher<Sponsor[]>('/info/about-festival/sponsors/');
+//   } catch (error) {
+//     throw error;
+//   }
 
-  return {
-    props: {
-      sponsors,
-    }
-  };
+//   return {
+//     props: {
+//       sponsors,
+//     }
+//   };
+// };
+
+// export default Sponsors;
+
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const Sponsors = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/about-us/404');
+  }, [router]);
+
+  return null;
 };
 
 export default Sponsors;

--- a/src/pages/about-us/team/index.tsx
+++ b/src/pages/about-us/team/index.tsx
@@ -1,46 +1,61 @@
-import { SEO } from 'components/seo';
+// import { SEO } from 'components/seo';
 
-import { AppLayout } from 'components/app-layout';
-import { AboutUsLayout } from 'components/about-us-layout';
-import ArtDirectorateSection from 'components/team-page/art-directorate/section/art-directorate-section';
-import FestivalTeamSection from 'components/team-page/festival-team/festival-team-section';
-import { fetcher } from 'services/fetcher';
+// import { AppLayout } from 'components/app-layout';
+// import { AboutUsLayout } from 'components/about-us-layout';
+// import ArtDirectorateSection from 'components/team-page/art-directorate/section/art-directorate-section';
+// import FestivalTeamSection from 'components/team-page/festival-team/festival-team-section';
+// import { fetcher } from 'services/fetcher';
 
-import type { InferGetServerSidePropsType } from 'next';
-import type { FestivalTeams } from 'api-typings';
+// import type { InferGetServerSidePropsType } from 'next';
+// import type { FestivalTeams } from 'api-typings';
 
-const Team = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const {
-    artDirectorate,
-    restTeam,
-  } = props;
+// const Team = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+//   const {
+//     artDirectorate,
+//     restTeam,
+//   } = props;
 
-  return (
-    <AppLayout>
-      <SEO title="Организаторы"/>
-      <AboutUsLayout>
-        <ArtDirectorateSection cards={artDirectorate}/>
-        <FestivalTeamSection cards={restTeam}/>
-      </AboutUsLayout>
-    </AppLayout>
-  );
-};
+//   return (
+//     <AppLayout>
+//       <SEO title="Организаторы"/>
+//       <AboutUsLayout>
+//         <ArtDirectorateSection cards={artDirectorate}/>
+//         <FestivalTeamSection cards={restTeam}/>
+//       </AboutUsLayout>
+//     </AppLayout>
+//   );
+// };
 
-export const getServerSideProps = async () => {
-  const team = await fetcher<FestivalTeams[]>('/info/about-festival/team/');
+// export const getServerSideProps = async () => {
+//   const team = await fetcher<FestivalTeams[]>('/info/about-festival/team/');
 
-  const { art: artDirectorate, fest: restTeam } = team.reduce<Record<string, FestivalTeams[]>>((acc, entry) => {
-    (acc[entry.team] || (acc[entry.team] = [])).push(entry);
+//   const { art: artDirectorate, fest: restTeam } = team.reduce<Record<string, FestivalTeams[]>>((acc, entry) => {
+//     (acc[entry.team] || (acc[entry.team] = [])).push(entry);
 
-    return acc;
-  }, {});
+//     return acc;
+//   }, {});
 
-  return {
-    props: {
-      artDirectorate,
-      restTeam,
-    },
-  };
+//   return {
+//     props: {
+//       artDirectorate,
+//       restTeam,
+//     },
+//   };
+// };
+
+// export default Team;
+
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const Team = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/about-us/404');
+  }, [router]);
+
+  return null;
 };
 
 export default Team;

--- a/src/shared/constants/about-us-navigation-items.ts
+++ b/src/shared/constants/about-us-navigation-items.ts
@@ -4,16 +4,16 @@ export const aboutUsNavigationItems = [
     text: 'Что мы делаем',
     href: '/about-us'
   },
-  {
-    id: 'team',
-    text: 'Организаторы',
-    href: '/about-us/team'
-  },
-  {
-    id: 'sponsors',
-    text: 'Попечители',
-    href: '/about-us/sponsors'
-  },
+  // {
+  //   id: 'team',
+  //   text: 'Организаторы',
+  //   href: '/about-us/team'
+  // },
+  // {
+  //   id: 'sponsors',
+  //   text: 'Попечители',
+  //   href: '/about-us/sponsors'
+  // },
   {
     id: 'mission',
     text: 'Миссия',

--- a/src/shared/constants/footer-navigation-items.ts
+++ b/src/shared/constants/footer-navigation-items.ts
@@ -23,10 +23,10 @@ export const footerNavigationItems = [
     text: 'О фестивале',
     href: '/about-us',
   },
-  {
-    text: 'Организаторы',
-    href: '/about-us/team',
-  },
+  // {
+  //   text: 'Организаторы',
+  //   href: '/about-us/team',
+  // },
   {
     text: 'История',
     href: '/history',


### PR DESCRIPTION
## Описание
Задача изменилась: скрыть разделы Попечители и Организаторы из навигации и футера, а также закрыть эти роуты. Закомментировала список ссылок в навигации и футере, компоненты Sponsors и Team закомментировала и сделала редирект на страницу 404.

## Ссылка на задачу
Реализовать условное отображение разделов "Организаторы" и "Попечители". https://www.notion.so/3a800b44f810445f99d4a107a8a641ee?pvs=4
