### PR TITLE
fix: поле Название в форме ограничено 200 символами

### DIFF
--- a/src/pages/form/form.tsx
+++ b/src/pages/form/form.tsx
@@ -273,7 +273,7 @@ const Participation = () => {
                     <TextInput
                       value={form.values.title}
                       placeholder="Название"
-                      errorText={form.touched.email ? form.errors.title : ''}
+                      errorText={form.touched.title ? form.errors.title : ''}
                       onChange={(value) => form.setFieldValue('title', value)}
                     />
                   </FormField>


### PR DESCRIPTION
## Описание
Поле ввода "Название" пьесы в форме ограничено 200 символами. При вводе более 200 символов браузер отображает сообщение об ошибке.

## Ссылка на задачу
[При вводе более 200 символов в поле “Название” на странице формы подачи пьесы ошибка не появляется](https://www.notion.so/200-722ec59e6cc34c72b696f4e66094b0ca)

## Скрины
![image](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/119502776/6ff9f8de-d82f-4866-85d3-9fa43fe85be4)

![image](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/119502776/41908f96-1e9b-4939-b78e-f789898600f9)


