### PR TITLE
fix: ошибка при валидации email

### DIFF
--- a/src/shared/constants/regexps.ts
+++ b/src/shared/constants/regexps.ts
@@ -1,3 +1,3 @@
 export const validYearRegexp = /^(19|20)[0-9]{2}$/;
 export const validPhoneNumberRegexp = /[\d]{2}$/;
-export const validEmailRegexp = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+export const validEmailRegexp = /^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/;


### PR DESCRIPTION
## Описание
На странице контакты. В поле “Е-mail для ответа” если вести кириллицу сайт зависает. Ошибка в регулярном выражении, валидирующем email, заменил регулярку.
![screen](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/64360318/0446b36c-b9f4-4ece-802b-61bc91188962)

## Ссылка на задачу
[На странице контакты. В поле “Е-mail для ответа” если вести кириллицу сайт зависает.](https://www.notion.so/mail-0f1a1b45930841009c1ada5c8175c10d)
