### PR TITLE
fix: изменен цвет шрифта для ссылок в хедере

### DIFF
--- a/src/components/ui/menu/type/main-navigation.module.css
+++ b/src/components/ui/menu/type/main-navigation.module.css
@@ -16,7 +16,7 @@
 
   display: flex;
   align-items: flex-start;
-  color: inherit;
+  color: var(--coal);
   text-decoration: none;
   white-space: nowrap;
 


### PR DESCRIPTION
## Описание
Цвет шрифта #000000 вместо #242424 в хэдере страницы конкретного блога. Изменил цвет шрифта.

## Ссылка на задачу
[Цвет шрифта #000000 вместо #242424 в хэдере страницы конкретного блога](https://www.notion.so/000000-242424-eec1902f94e64f26a93fd6dbae7910f5)
