### PR TITLE
fix: исправлен модуль entry-card

### DIFF
--- a/src/components/blog-entry-card/blog-entry-card.module.css
+++ b/src/components/blog-entry-card/blog-entry-card.module.css
@@ -69,7 +69,6 @@
   order: 4;
   margin: 0 0 0 28px;
   hyphens: auto;
-  white-space: wrap;
   word-break: break-all;
 
   @mixin textSmall;

--- a/src/components/blog-entry-card/blog-entry-card.module.css
+++ b/src/components/blog-entry-card/blog-entry-card.module.css
@@ -65,8 +65,12 @@
 }
 
 .description {
+  overflow: hidden;
   order: 4;
   margin: 0 0 0 28px;
+  hyphens: auto;
+  white-space: wrap;
+  word-break: break-all;
 
   @mixin textSmall;
 }

--- a/src/components/constructor-content/variant/default.module.css
+++ b/src/components/constructor-content/variant/default.module.css
@@ -16,6 +16,8 @@
 
   max-width: 720px;
   margin: 0 auto 48px;
+  hyphens: auto;
+  word-break: break-all;
 
   @media (max-width: $tablet-portrait) {
     @mixin headline6;


### PR DESCRIPTION
## Описание
На странице Блог центрирует контент.
Основной текст и заголовки переносятся на новую строку при достижении границы. При этом очень-длинное-слово (набор слов без пробелов) также переносится.

## Ссылка на задачу
[Страница Блог скукоживается на мобилке](https://www.notion.so/7b2bb17fb3084bda9da5b57f0eda9451)

## Результат
![image](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/119502776/51e09c07-3762-46b7-b02f-a2037afb749e)

