### PR TITLE
fix: исправлено поведение при смене ориентации экрана

### DIFF
--- a/src/components/app-layout/app-layout.tsx
+++ b/src/components/app-layout/app-layout.tsx
@@ -45,6 +45,7 @@ export const AppLayout: React.VFC<React.PropsWithChildren<AppLayoutProps>> = (pr
   const { settings } = useSettings();
   const { partners } = usePartners({ onlyGeneral: true });
   const [isOverlayMenuOpen, setIsOverlayMenuOpen] = useState(false);
+  const [scrollPosition, setScrollPosition] = useState(0);
   const isMobile = useMediaQuery(`(max-width: ${breakpoints['tablet-portrait']})`);
   const router = useRouter();
 
@@ -59,6 +60,20 @@ export const AppLayout: React.VFC<React.PropsWithChildren<AppLayoutProps>> = (pr
       setIsOverlayMenuOpen(false);
     }
   }, [isMobile]);
+
+  useEffect(() => {
+    const onChange = () => {
+      setScrollPosition(window.scrollY);
+      if (screen.orientation.type === 'landscape-primary') {
+        window.scroll(0, scrollPosition * (window.outerWidth / window.outerHeight));
+      }
+    };
+    screen.orientation.addEventListener('change', onChange);
+
+    return () => {
+      screen.orientation.removeEventListener('change', onChange);
+    };
+  }, [scrollPosition]);
 
   return (
     <Page>
@@ -227,3 +242,4 @@ export const AppLayout: React.VFC<React.PropsWithChildren<AppLayoutProps>> = (pr
     </Page>
   );
 };
+

--- a/src/components/seo/seo.tsx
+++ b/src/components/seo/seo.tsx
@@ -26,6 +26,7 @@ export const SEO: React.FC<SEOProps> = (props) => {
       <title>
         {`${title} - ${settings.defaultMeta.title}`}
       </title>
+      <meta name="viewport" content="width=device-width, initial-scale=1"/>
       <meta name="description" content={description}/>
       <meta name="image" content={image}/>
       <meta property="og:title" content={title}/>


### PR DESCRIPTION
## Описание
Страница Блога отображает среднюю часть body при смене ориентации экрана с альбомной на портретную и на альбомную (при изначальном отображении на экране нижней части страницы). При переходе на альбомную ориентацию экрана страница скролится на позицию, которая была в портретной * на отношение ширины и высоты экрана, что примерно соответствует той позиции, которая была до смены ориентации экрана.

## Ссылка на задачу
[Страница Блога отображает среднюю часть body при смене ориентации экрана с альбомной на портретную и на альбомную (при изначальном отображении на экране нижней части страницы)](https://www.notion.so/body-5f941a0d1d2c4e628a38cfbced8970c5)
