### PR TITLE
fix: исправлены стили в блоке пьес на странице конкретного блога

### DIFF
--- a/src/components/play-card/play-card.module.css
+++ b/src/components/play-card/play-card.module.css
@@ -8,7 +8,8 @@
   background-color: var(--light-green);
 
   @media tablet-portrait {
-    min-height: 340px;
+    min-height: 342px;
+    margin: 0 0 24px;
   }
 }
 

--- a/src/components/play-list/play-list.module.css
+++ b/src/components/play-list/play-list.module.css
@@ -17,6 +17,7 @@ $item-width: 240px;
 
     padding: 0 24px;
     margin: 0 -24px;
+    gap: 0;
     overflow-y: auto;
   }
 }
@@ -32,11 +33,11 @@ $item-width: 240px;
 
   @media (max-width: $tablet-portrait) {
     position: relative;
-    min-width: 302px;
+    min-width: 244px;
     border-top: 0;
 
     &:not(:last-child) {
-      margin-right: 32px;
+      margin-right: 31px;
     }
   }
 }


### PR DESCRIPTION
## Описание
Не помещаются на экране первые два превью в блоке пьес на странице конкретного блока для мобильного устройства. Исправил стили в блоке пьес конкретного блога.

## Ссылка на задачу
[Не помещаются на экране первые два превью в блоке пьес на странице конкретного блока для мобильного устройства](https://www.notion.so/23ab7f104db34e81a1e7a4f95bbae592)
