### PR TITLE
fix: логотип в футере сделан ссылкой, ведущей на главную

### DIFF
--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -30,6 +30,10 @@
   }
 }
 
+.logo:hover {
+  cursor: pointer;
+}
+
 .footnote {
   margin-top: 49px;
   color: var(--coal);

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames/bind';
+import Link from 'next/link';
 
 import { FooterCopyright } from 'components/footer-copyright';
 import Logo from 'shared/images/full-logo.svg';
@@ -28,7 +29,9 @@ export const Footer = (props: FooterProps): JSX.Element => {
 
   return (
     <footer className={cx('footer', className)}>
-      <Logo className={cx('logo')}/>
+      <Link href="/">
+        <Logo className={cx('logo')}/>
+      </Link>
       {children}
       <FooterCopyright
         className={cx('footnote')}


### PR DESCRIPTION
## Описание
Не происходит переход на главную страницу при клике на лого в футере страницы блога. Лого в футере обернуто в ссылку на главную страницу.

## Ссылка на задачу
[Не происходит переход на главную страницу при клике на лого в футере страницы блога](https://www.notion.so/5ebaafc679a34b24aba55666670a9e03)
