### PR TITLE
feat: добавлены тесты для полей ввода формы подачи пьесы

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+});

--- a/cypress/e2e/city-input.cy.ts
+++ b/cypress/e2e/city-input.cy.ts
@@ -1,0 +1,38 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field contains less than 2 symbols', ()=>{
+    cy.get(classes.input.city).type('x'.repeat(1));
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.minLengh);
+  });
+
+  it('Checks whether the error message is hidden when the field contains 2 symbols', ()=>{
+    cy.get(classes.input.city).type('x'.repeat(2));
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message is hidden when the field contains 50 symbols', ()=>{
+    cy.get(classes.input.city)
+      .type('x'.repeat(50));
+
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message appears when the field contains more than 50 symbols', ()=>{
+    cy.get(classes.input.city)
+      .type('x'.repeat(51));
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.maxLengthFifty);
+  });
+
+});

--- a/cypress/e2e/email-input.cy.ts
+++ b/cypress/e2e/email-input.cy.ts
@@ -1,0 +1,40 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+const mockEmails = {
+  correct: 'email@mail.com',
+  noDog: 'email.mail',
+  noDot: 'email@mail'
+};
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field remaines empty', ()=>{
+    cy.get(classes.input.email).type(mockEmails.correct);
+    cy.get(classes.input.email).clear();
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.empty);
+  });
+
+  it('Checks whether the error message appears when email has no @', ()=>{
+    cy.get(classes.input.email).type(mockEmails.noDog);
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.incorrectEmail);
+  });
+
+  it('Checks whether the error message appears when email has no .', ()=>{
+    cy.get(classes.input.email).type(mockEmails.noDot);
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.incorrectEmail);
+  });
+
+});

--- a/cypress/e2e/first-name-input.cy.ts
+++ b/cypress/e2e/first-name-input.cy.ts
@@ -1,0 +1,47 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field remaines empty', ()=>{
+    cy.get(classes.input.name).type('x'.repeat(1));
+    cy.get(classes.input.name).clear();
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.empty);
+  });
+
+  it('Checks whether the error message appears when the field contains less than 2 symbols', ()=>{
+    cy.get(classes.input.name).type('x'.repeat(1));
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.minLengh);
+  });
+
+  it('Checks whether the error message is hidden when the field contains 2 symbols', ()=>{
+    cy.get(classes.input.name).type('x'.repeat(2));
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message is hidden when the field contains 50 symbols', ()=>{
+    cy.get(classes.input.name)
+      .type('x'.repeat(50));
+
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message appears when the field contains more than 50 symbols', ()=>{
+    cy.get(classes.input.name)
+      .type('x'.repeat(51));
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.maxLengthFifty);
+  });
+
+});

--- a/cypress/e2e/last-name-input.cy.ts
+++ b/cypress/e2e/last-name-input.cy.ts
@@ -1,0 +1,41 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field remaines empty', ()=>{
+    cy.get(classes.input.surname).type('x'.repeat(1));
+    cy.get(classes.input.surname).clear();
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.empty);
+  });
+
+  it('Checks whether the error message appears when the field contains less than 2 symbols', ()=>{
+    cy.get(classes.input.surname).type('x'.repeat(1));
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.minLengh);
+  });
+
+  it('Checks whether the error message is hidden when the field contains 2 symbols', ()=>{
+    cy.get(classes.input.surname).type('x'.repeat(2));
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message is hidden when the field contains 50 symbols', ()=>{
+    cy.get(classes.input.surname).type('x'.repeat(50));
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message appears when the field contains more than 50 symbols', ()=>{
+    cy.get(classes.input.surname).type('x'.repeat(51));
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.maxLengthFifty);
+  });
+
+});

--- a/cypress/e2e/phone-input.cy.ts
+++ b/cypress/e2e/phone-input.cy.ts
@@ -1,0 +1,31 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+const mockPhones = {
+  correct: '9999999999',
+  eigthDigits: '99999999',
+};
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field remaines empty', ()=>{
+    cy.get(classes.input.phone).type(mockPhones.correct);
+    cy.get(classes.input.phone).clear();
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.empty);
+  });
+
+  it('Checks whether the error message appears when the field contains insufficient number of digits', ()=>{
+    cy.get(classes.input.phone).type(mockPhones.eigthDigits);
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.incorrectPhone);
+  });
+
+});

--- a/cypress/e2e/title-input.cy.ts
+++ b/cypress/e2e/title-input.cy.ts
@@ -1,0 +1,41 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field remaines empty', ()=>{
+    cy.get(classes.input.title).type('x'.repeat(1));
+    cy.get(classes.input.title).clear();
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.empty);
+  });
+
+  it('Checks whether the error message is hidden when the field contains 1 symbol', ()=>{
+    cy.get(classes.input.title).type('x'.repeat(1));
+
+    cy.get(classes.error)
+      .should('not.exist');
+  });
+
+  it('Checks whether the error message is hidden when the field contains 200 symbols', ()=>{
+    cy.get(classes.input.title)
+      .type('x'.repeat(200));
+
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message appears when the field contains more than 200 symbols', ()=>{
+    cy.get(classes.input.title)
+      .type('x'.repeat(201));
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.maxLengthTwoHundred);
+  });
+
+});

--- a/cypress/e2e/year-birth-input.cy.ts
+++ b/cypress/e2e/year-birth-input.cy.ts
@@ -1,0 +1,34 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+const MOCK_CURRENT_YEAR = new Date().getFullYear();
+const maxYearMessage = `Убедитесь, что это значение меньше либо равно ${MOCK_CURRENT_YEAR}`;
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field contains 1899', ()=>{
+    cy.get(classes.input.yearBirth).type('1899');
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.minYear);
+  });
+
+  it('Checks whether the error message is hidden when the field contains current year', ()=>{
+    cy.get(classes.input.yearBirth).type(`${MOCK_CURRENT_YEAR}`);
+
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message appears when the field contains post-current year', ()=>{
+    cy.get(classes.input.yearBirth).type(`${MOCK_CURRENT_YEAR + 1}`);
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(maxYearMessage);
+  });
+
+});

--- a/cypress/e2e/year-play-input.cy.ts
+++ b/cypress/e2e/year-play-input.cy.ts
@@ -1,0 +1,34 @@
+import { classes, errorMessages } from '../fixtures/test-constants.json';
+
+const MOCK_CURRENT_YEAR = new Date().getFullYear();
+const maxYearMessage = `Убедитесь, что это значение меньше либо равно ${MOCK_CURRENT_YEAR}`;
+
+describe('form', ()=> {
+
+  beforeEach(()=>{
+    cy.visit('/form');
+  });
+
+  it('Checks whether the error message appears when the field contains 1899', ()=>{
+    cy.get(classes.input.yearPlay).type('1899');
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(errorMessages.minYear);
+  });
+
+  it('Checks whether the error message is hidden when the field contains current year', ()=>{
+    cy.get(classes.input.yearPlay).type(`${MOCK_CURRENT_YEAR}`);
+
+    cy.get(classes.error).should('not.exist');
+  });
+
+  it('Checks whether the error message appears when the field contains post-current year', ()=>{
+    cy.get(classes.input.yearPlay).type(`${MOCK_CURRENT_YEAR + 1}`);
+
+    cy.get(classes.error)
+      .should('exist')
+      .contains(maxYearMessage);
+  });
+
+});

--- a/cypress/fixtures/test-constants.json
+++ b/cypress/fixtures/test-constants.json
@@ -1,0 +1,25 @@
+{
+    "errorMessages": {
+        "empty": "Это поле не может быть пустым",
+        "minLengh": "Это поле должно содержать минимум 2 символа",
+        "maxLengthFifty": "Это поле должно содержать максимум 50 символов",
+        "maxLengthTwoHundred": "Это поле должно содержать максимум 200 символов",
+        "minYear": "Убедитесь, что это значение больше либо равно 1900",
+        "incorrectPhone": "Некорректный номер телефона",
+        "incorrectEmail": "Введите правильный адрес электронной почты",
+        "noFile": "Файл обязателен"
+    },
+    "classes": {
+        "input" : {
+            "name": ":nth-child(1) > .form-fieldset_content__6DaOu > :nth-child(1) > label > .text-input_input__XcJF1",
+            "surname": ":nth-child(1) > .form-fieldset_content__6DaOu > :nth-child(2) > label > .text-input_input__XcJF1",
+            "city": ":nth-child(4) > label > .text-input_input__XcJF1",
+            "yearBirth": ":nth-child(3) > label > .text-input_input__XcJF1",
+            "yearPlay": ":nth-child(2) > .form-fieldset_content__6DaOu > :nth-child(2) > label > .text-input_input__XcJF1",
+            "title": ":nth-child(2) > .form-fieldset_content__6DaOu > :nth-child(1) > label > .text-input_input__XcJF1",
+            "email": ":nth-child(6) > label > .text-input_input__XcJF1",
+            "phone": ":nth-child(5) > label > .text-input_input__XcJF1"
+        },
+        "error" : ".text-input_error__7FtZe"
+    }
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,0 +1,38 @@
+/* eslint-disable eol-last */
+/// <reference types="cypress" />
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,22 @@
+/* eslint-disable semi */
+/* eslint-disable eol-last */
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/src/pages/form/form.tsx
+++ b/src/pages/form/form.tsx
@@ -44,69 +44,81 @@ const initialFormValues: ParticipationFormFields = {
   file: null,
 };
 
+const errorMessage = {
+  empty: 'Это поле не может быть пустым',
+  minLengh: 'Это поле должно содержать минимум 2 символа',
+  maxLengthFifty: 'Это поле должно содержать максимум 50 символов',
+  maxLengthTwoHundred: 'Это поле должно содержать максимум 200 символов',
+  minYear: 'Убедитесь, что это значение больше либо равно 1900',
+  maxYear: `Убедитесь, что это значение меньше либо равно ${CURRENT_YEAR}`,
+  incorrectPhone: 'Некорректный номер телефона',
+  incorrectEmail: 'Введите правильный адрес электронной почты',
+  noFile: 'Файл обязателен'
+};
+
 const validate = (values: ParticipationFormFields) => {
   const errors = {} as Record<keyof ParticipationFormFields, string>;
 
   if (!values.firstName.length) {
-    errors.firstName = 'Это поле не может быть пустым';
+    errors.firstName = errorMessage.empty;
   } else if (values.firstName.length < 2) {
-    errors.firstName = 'Имя должно состоять более чем из 2 символов';
+    errors.firstName = errorMessage.minLengh;
   } if (values.firstName.length > 50) {
-    errors.firstName = 'Имя должно состоять менее чем из 50 символов';
+    errors.firstName = errorMessage.maxLengthFifty;
   }
 
   if (!values.lastName.length) {
-    errors.lastName = 'Это поле не может быть пустым';
+    errors.lastName = errorMessage.empty;
   } else if (values.lastName.length < 2) {
-    errors.lastName = 'Фамилия должна содержать минимум 2 символа';
+    errors.lastName = errorMessage.minLengh;
   } else if (values.lastName.length > 50) {
-    errors.lastName = 'Фамилия должна состоять менее чем из 50 символов';
+    errors.lastName = errorMessage.maxLengthFifty;
   }
 
   if (!values.birthYear.length) {
-    errors.birthYear = 'Это поле не может быть пустым';
+    errors.birthYear = errorMessage.empty;
   } else if (!validYearRegexp.test(values.birthYear)) {
-    errors.birthYear = 'Убедитесь, что это значение больше либо равно 1900';
+    errors.birthYear = errorMessage.minYear;
   } else if (values.birthYear > CURRENT_YEAR) {
-    errors.birthYear = `Убедитесь, что это значение меньше либо равно ${CURRENT_YEAR}`;
+    errors.birthYear = errorMessage.maxYear;
   }
 
   if (!values.city.length) {
-    errors.city = 'Это поле не может быть пустым';
+    errors.city = errorMessage.empty;
   } else if (values.city.length < 2) {
-    errors.city = 'Город должен содержать минимум 2 символа';
+    errors.city = errorMessage.minLengh;
   } else if (values.city.length > 50) {
-    errors.city = 'Город должен состоять менее чем из 50 символов';
+    errors.city = errorMessage.maxLengthFifty;
   }
 
   if (!values.phoneNumber.length) {
-    errors.phoneNumber = 'Это поле не может быть пустым';
+    errors.phoneNumber = errorMessage.empty;
   } else if (!validPhoneNumberRegexp.test(values.phoneNumber)) {
-    errors.phoneNumber = 'Некорректный номер телефона';
+    errors.phoneNumber = errorMessage.incorrectPhone;
   }
 
   if (!values.email.length) {
-    errors.email = 'Это поле не может быть пустым';
+    errors.email = errorMessage.empty;
   } else if (!validEmailRegexp.test(values.email)) {
-    errors.email = 'Введите правильный адрес электронной почты';
+    errors.email = errorMessage.incorrectEmail;
   }
 
   if (!values.title.length) {
-    errors.title = 'Это поле не может быть пустым';
+    errors.title = errorMessage.empty;
   } else if (values.title.length > 200) {
-    errors.title = 'Название пьесы должно состоять менее чем из 200 символов';
+    errors.title = errorMessage.maxLengthTwoHundred;
   }
 
   if (!values.year.length) {
-    errors.year = 'Это поле не может быть пустым';
+    errors.year = errorMessage.empty;
   } else if (!validYearRegexp.test(values.year)) {
-    errors.year = 'Убедитесь, что это значение больше либо равно 1900';
+    errors.year = errorMessage.minYear;
   } else if (values.year > CURRENT_YEAR) {
-    errors.year = `Убедитесь, что это значение меньше либо равно ${CURRENT_YEAR}`;
+    errors.year = errorMessage.maxYear;
   }
 
   if (!values.file) {
-    errors.file = 'Файл обязателен';
+    errors.file = errorMessage.noFile;
   }
 
   return errors;


### PR DESCRIPTION
## Описание
Данный пулл-реквест содержит тесты для полей ввода формы подачи пьесы.
Тесты проверяют наличие сообщения об ошибке при вводе некорректных данных и отсутствие такого сообщения при вводе корректных данных (для каждого поля в отдельности).

## Ссылка на задачу
[Написать e2e-тесты](https://www.notion.so/e2e-10897b6836094aa4b5db29820e50d043)

## Проблемы и трудности
1) При тестировании полей ввода Телефона и E-mail (а они валидируются в компонентом с применением регулярных выражений), при вводе некорректных данных сообщение об ошибке выдает только E-mail.
2) Пока не понятно, как сделать тест активации (деактивации) кнопки отправки заявки (submit-button).
3) Пока не понятно, как сделать тест для загрузки и отправки прикрепленного файла.