### PR TITLE
fix: исправление стилей для страницы библиотека

### DIFF
--- a/src/components/author-list/item/author-list-item.module.css
+++ b/src/components/author-list/item/author-list-item.module.css
@@ -1,3 +1,7 @@
 .root {
   display: block;
+
+  a {
+    width: 100%;
+  }
 }

--- a/src/components/library-layout/library-layout.module.css
+++ b/src/components/library-layout/library-layout.module.css
@@ -32,6 +32,7 @@
 
   @media tablet-portrait {
     padding: 0 24px;
+    background-color: var(--white);
   }
 }
 
@@ -63,6 +64,7 @@
     position: static;
     z-index: auto;
     padding: 0 24px;
+    background-color: var(--white);
   }
 }
 
@@ -76,9 +78,11 @@
   grid-area: navigation;
 
   @media tablet-portrait {
-    z-index: 1;
+    z-index: 2;
     top: 0;
-    border-bottom: 1px solid var(--coal);
+    box-sizing: border-box;
+    padding-top: 26px;
+    background-color: var(--white);
   }
 }
 
@@ -93,7 +97,7 @@
 
 .pagination {
   position: sticky;
-  z-index: 3;
+  z-index: 1;
   top: calc(var(--height-navbar-tablet-portrait) + var(--height-library-navigation-menu-tablet-portrait));
   display: flex;
   border-bottom: 1px solid var(--coal);
@@ -107,8 +111,14 @@
 
     top: var(--height-library-navigation-menu-tablet-portrait);
     display: block;
-    margin: 0 0 56px;
+    margin: 0;
+    background-color: var(--white);
     overflow-x: auto;
+
+    nav {
+      border-top: 1px solid var(--coal);
+      margin-top: 16px;
+    }
   }
 }
 
@@ -135,6 +145,12 @@
   .search {
     top: calc(var(--height-navbar-tablet-portrait) + 24px);
     max-width: 580px;
+  }
+
+  .content {
+    @media tablet-portrait {
+      padding-top: 56px;
+    }
   }
 }
 
@@ -183,9 +199,11 @@
     overflow-y: auto;
 
     @media tablet-portrait {
-      position: static;
+      z-index: 1;
+      top: 80px;
       height: auto;
-      padding: 16px 24px;
+      padding: 10px 24px 16px;
+      background-color: var(--white);
       overflow-x: auto;
     }
   }

--- a/src/components/page/navbar/page-navbar.module.css
+++ b/src/components/page/navbar/page-navbar.module.css
@@ -11,5 +11,6 @@
     position: static;
     z-index: auto;
     border: 0;
+    background-color: var(--white);
   }
 }

--- a/src/components/play-card/play-card.module.css
+++ b/src/components/play-card/play-card.module.css
@@ -44,14 +44,17 @@
 
 .author {
   display: inline-block;
+  max-width: 100%;
   padding: 0;
   margin-inline-start: 0;
+  overflow-x: hidden;
 
   :first-child {
     font-family: "PP Neue Machina", Arial, sans-serif;
     font-weight: 400;
     letter-spacing: -.01em;
     line-height: 24px;
+    text-overflow: ellipsis;
   }
 }
 

--- a/src/components/ui/menu/type/library-navigation.module.css
+++ b/src/components/ui/menu/type/library-navigation.module.css
@@ -34,7 +34,7 @@
   &::after {
     display: block;
     width: .6em;
-    height: 1.6em;
+    height: 1.5em;
     box-sizing: border-box;
     border: 1px solid currentColor;
     content: "";


### PR DESCRIPTION
## Описание
Исправление стилей для страницы библиотека.  
Исправил шапку и переполнение текста в карточках.

<img width="299" alt="image" src="https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/93670312/84b3d13e-425d-4fa8-a280-5a6e7754952c">
<img width="297" alt="image" src="https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/93670312/0fd1d5a6-29d4-4bee-99fd-801e3e148bcb">
<img width="214" alt="image" src="https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/assets/93670312/7d315aa4-9698-4206-9ac1-611b5c61d67d">


## Ссылка на задачу
[Привести страницы авторов и пьес в библиотеке к дизайну](https://www.notion.so/1622363f3290431f95cd462e2d1ab082?pvs=4)
