### PR TITLE
fix: исправлено открытие блога при клике по фотографии

### DIFF
--- a/src/components/blog-entry-card/blog-entry-card.module.css
+++ b/src/components/blog-entry-card/blog-entry-card.module.css
@@ -48,6 +48,7 @@
     width: 100%;
     height: 100%;
     content: "";
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
## Описание
Можно перейти на страницу блога из раздела Блог Любимовки кликнув по фотографии в карточке в браузере Firefox. Исправлено.

## Ссылка на задачу
[Можно перейти на страницу блога из раздела Блог Любимовки кликнув по фотографии в карточке в браузере Firefox](https://www.notion.so/Firefox-050a1e358a2a4d97b084054c59c2ab4c)
