### PR TITLE
fix: исправить открытие ссылок соцсетей на странице авторов

### DIFF
--- a/src/components/author-page/overview/overview.tsx
+++ b/src/components/author-page/overview/overview.tsx
@@ -222,6 +222,8 @@ export const AuthorOverview: React.FC<IAuthorOverview> = (props) => {
                       size="s"
                       border='bottom-left'
                       href={item.link}
+                      target='_blank'
+                      rel='noopener noreferrer'
                       icon={(
                         <Icon
                           glyph="arrow-right"


### PR DESCRIPTION
## Описание
Этот Pull Request исправляет поведение ссылок на странице авторов. Теперь при клике на ссылки социальных сетей они открываются в новой вкладке.

## Ссылка на задачу
[Открытие ссылок соцсетей в новых вкладках#552](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/552#issue-2423903651 )
