### PR TITLE
block-submit-button

### DIFF
--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -82,6 +82,16 @@ const contactFormReducer = (state: ContactFormState, action: ContactFormAction) 
   }
 };
 
+const getSubmitButtonText = (formSuccessfullySent: boolean, isSubmitting: boolean) => {
+  if (formSuccessfullySent) {
+    return 'Отправлено';
+  } else if (isSubmitting) {
+    return 'Отправляется';
+  }
+
+  return 'Отправить';
+};
+
 const Contacts: NextPage = () => {
   const [contactFormState, dispatch] = useReducer(contactFormReducer, initialContactFormState);
   const [formSuccessfullySent, setFormSuccessfullySent] = useState(false);
@@ -154,7 +164,7 @@ const Contacts: NextPage = () => {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setIsSubmitting(true); 
+    setIsSubmitting(true);
 
     const data = {
       author_name: name.value,
@@ -166,7 +176,7 @@ const Contacts: NextPage = () => {
       await fetcher('/feedback/questions/', {
         method: 'POST',
         headers: {
-          'Content-type': 'application/json',
+          'Content-type': 'application/json'
         },
         body: JSON.stringify(data),
       });
@@ -256,11 +266,11 @@ const Contacts: NextPage = () => {
                   )}
                   iconPosition="right"
                   border="full"
-                  disabled={!canSubmit || isSubmitting} 
+                  disabled={!canSubmit || isSubmitting}
                   upperCase
                   fullWidth
                 >
-                  {formSuccessfullySent ? 'Отправлено' : isSubmitting ? 'Отправляется' : 'Отправить'}
+                  {getSubmitButtonText(formSuccessfullySent, isSubmitting)}
                 </Button>
               </Form.Actions>
               <Form.Disclaimer className={styles.container}>

--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -85,6 +85,7 @@ const contactFormReducer = (state: ContactFormState, action: ContactFormAction) 
 const Contacts: NextPage = () => {
   const [contactFormState, dispatch] = useReducer(contactFormReducer, initialContactFormState);
   const [formSuccessfullySent, setFormSuccessfullySent] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { settings } = useSettings();
 
   const {
@@ -151,8 +152,10 @@ const Contacts: NextPage = () => {
     setTimeout(() => setFormSuccessfullySent(false), CONTACT_FORM_RESET_TIMEOUT);
   };
 
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setIsSubmitting(true); 
 
     const data = {
       author_name: name.value,
@@ -164,10 +167,13 @@ const Contacts: NextPage = () => {
       await fetcher('/feedback/questions/', {
         method: 'POST',
         headers: {
-          'Content-type': 'application/json'
+          'Content-type': 'application/json',
         },
         body: JSON.stringify(data),
       });
+
+      setFormSuccessfullySent(true);
+      resetContactForm();
     } catch (err) {
       if (isHttpRequestError(err)) {
         const { statusCode } = err.response;
@@ -192,10 +198,9 @@ const Contacts: NextPage = () => {
           throw new InternalServerError();
         }
       }
+    } finally {
+      setIsSubmitting(false);
     }
-
-    setFormSuccessfullySent(true);
-    resetContactForm();
   };
 
   const canSubmit = name.wasChanged && !name.error
@@ -252,11 +257,11 @@ const Contacts: NextPage = () => {
                   )}
                   iconPosition="right"
                   border="full"
-                  disabled={!canSubmit}
+                  disabled={!canSubmit || isSubmitting} 
                   upperCase
                   fullWidth
                 >
-                  {formSuccessfullySent ? 'Отправлено' : 'Отправить'}
+                  {formSuccessfullySent ? 'Отправлено' : isSubmitting ? 'Отправляется' : 'Отправить'}
                 </Button>
               </Form.Actions>
               <Form.Disclaimer className={styles.container}>

--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -85,7 +85,8 @@ const contactFormReducer = (state: ContactFormState, action: ContactFormAction) 
 const getSubmitButtonText = (formSuccessfullySent: boolean, isSubmitting: boolean) => {
   if (formSuccessfullySent) {
     return 'Отправлено';
-  } if (isSubmitting) {
+  } 
+  if (isSubmitting) {
     return 'Отправляется';
   }
 

--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -85,7 +85,7 @@ const contactFormReducer = (state: ContactFormState, action: ContactFormAction) 
 const getSubmitButtonText = (formSuccessfullySent: boolean, isSubmitting: boolean) => {
   if (formSuccessfullySent) {
     return 'Отправлено';
-  } else if (isSubmitting) {
+  } if (isSubmitting) {
     return 'Отправляется';
   }
 

--- a/src/pages/contacts/contacts.tsx
+++ b/src/pages/contacts/contacts.tsx
@@ -152,7 +152,6 @@ const Contacts: NextPage = () => {
     setTimeout(() => setFormSuccessfullySent(false), CONTACT_FORM_RESET_TIMEOUT);
   };
 
-
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsSubmitting(true); 


### PR DESCRIPTION
## Ссылка на задачу
[Блокировать кнопку отправки формы на странице контактов. #554](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/554)

При нажатии на кнопку отправки формы заменяет подпись кнопки на "Отправляется" и блокирует кнопку от повторного нажатия до получения ответа сервера.