### PR TITLE
Feature/issue 562/hide&show volunteers button settings

### DIFF
--- a/src/components/history-page/title/history-title.tsx
+++ b/src/components/history-page/title/history-title.tsx
@@ -13,12 +13,13 @@ import style from './history-title.module.css';
 interface IHistoryTitle {
   data: Festival
   currentYear: number
+  showVolunteers: boolean
 }
 
 // TODO: TT заменить на локальное изображение
 const imageUrl = 'https://s1.hostingkartinok.com/uploads/images/2021/12/fb0c8e1baf21b0ca306ee98a6678c0d8.png';
 
-export const HistoryTitle: React.FC<IHistoryTitle> = ({ data, currentYear }) => {
+export const HistoryTitle: React.FC<IHistoryTitle> = ({ data, currentYear, showVolunteers }) => {
   const {
     plays_count,
     selected_plays_count,
@@ -33,7 +34,6 @@ export const HistoryTitle: React.FC<IHistoryTitle> = ({ data, currentYear }) => 
     additional_links,
     description
   } = data;
-
   const formatDate = (date: string) => new Date(date).toLocaleDateString('ru-Ru', {
     timeZone: 'Europe/Moscow',
     month: 'long',
@@ -61,7 +61,7 @@ export const HistoryTitle: React.FC<IHistoryTitle> = ({ data, currentYear }) => 
     volunteers_count: {
       count: volunteers_count,
       title: 'волонтёров работали на фестивале',
-      buttonProps: {
+      buttonProps: showVolunteers ? {
         href: urlVolonters,
         iconPosition: 'right',
         icon: <Icon
@@ -69,7 +69,7 @@ export const HistoryTitle: React.FC<IHistoryTitle> = ({ data, currentYear }) => 
           width="100%"
           height="100%"
         />
-      }
+      } : null
     },
     events_count: {
       count: events_count,

--- a/src/components/history-page/title/history-title.tsx
+++ b/src/components/history-page/title/history-title.tsx
@@ -69,7 +69,7 @@ export const HistoryTitle: React.FC<IHistoryTitle> = ({ data, currentYear, showV
           width="100%"
           height="100%"
         />
-      } : null
+      } : undefined
     },
     events_count: {
       count: events_count,

--- a/src/pages/about-us/sponsors/index.tsx
+++ b/src/pages/about-us/sponsors/index.tsx
@@ -17,7 +17,7 @@ const Sponsors = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
   const permissions = settings?.permissions;
 
   const router = useRouter();
-  if (permissions && !permissions.sponsors) {
+  if (permissions && !permissions.show_sponsors) {
     router.replace('/about-us/404');
   }
 

--- a/src/pages/about-us/team/index.tsx
+++ b/src/pages/about-us/team/index.tsx
@@ -20,7 +20,7 @@ const Team = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => 
   const permissions = settings?.permissions;
 
   const router = useRouter();
-  if (permissions && !permissions.team) {
+  if (permissions && !permissions.show_team) {
     router.replace('/about-us/404');
   }
 

--- a/src/pages/history/[year].tsx
+++ b/src/pages/history/[year].tsx
@@ -82,7 +82,7 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
     }
   }
   const settings = await fetchSettings(); // Semicolon added
-  const showVolunteers = settings.permissions.volunteers;
+  const showVolunteers = settings.permissions.show_volunteers;
   
   return {
     props: {

--- a/src/pages/history/[year].tsx
+++ b/src/pages/history/[year].tsx
@@ -5,11 +5,11 @@ import { HistoryItself } from 'components/history-page/itself';
 import { HistoryTitle } from 'components/history-page/title';
 import { SEO } from 'components/seo';
 import { Menu } from 'components/ui/menu';
+import { fetchSettings } from 'services/api/settings-adapter';
 import { fetcher } from 'services/fetcher';
 import { notFoundResult } from 'shared/constants/server-side-props';
 import { InternalServerError } from 'shared/helpers/internal-server-error';
 import { useHorizontalScroll } from 'shared/hooks/use-horizontal-scroll';
-import { fetchSettings } from 'services/api/settings-adapter';
 
 import type { Festival, Years } from '__generated__/api-typings';
 import type { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
@@ -81,7 +81,7 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       throw new InternalServerError();
     }
   }
-  const settings = await fetchSettings()
+  const settings = await fetchSettings(); // Semicolon added
   const showVolunteers = settings.permissions.volunteers;
   
   return {

--- a/src/pages/history/[year].tsx
+++ b/src/pages/history/[year].tsx
@@ -9,6 +9,7 @@ import { fetcher } from 'services/fetcher';
 import { notFoundResult } from 'shared/constants/server-side-props';
 import { InternalServerError } from 'shared/helpers/internal-server-error';
 import { useHorizontalScroll } from 'shared/hooks/use-horizontal-scroll';
+import { fetchSettings } from 'services/api/settings-adapter';
 
 import type { Festival, Years } from '__generated__/api-typings';
 import type { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
@@ -80,8 +81,8 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       throw new InternalServerError();
     }
   }
-  const settings = await fetcher<{ show_volunteers: boolean }>('/info/settings/');
-  const showVolunteers = settings.show_volunteers;
+  const settings = await fetchSettings()
+  const showVolunteers = settings.permissions.volunteers;
   
   return {
     props: {

--- a/src/pages/history/[year].tsx
+++ b/src/pages/history/[year].tsx
@@ -17,7 +17,8 @@ const History = (props: InferGetServerSidePropsType<typeof getServerSideProps>) 
   const {
     years,
     festival,
-    defaultYear
+    defaultYear,
+    showVolunteers,
   } = props;
 
   const menuRef = useHorizontalScroll<HTMLUListElement>();
@@ -43,6 +44,7 @@ const History = (props: InferGetServerSidePropsType<typeof getServerSideProps>) 
         <HistoryTitle
           data={festival}
           currentYear={defaultYear}
+          showVolunteers={showVolunteers} 
         />
         <HistoryItself data={itselfData}/>
       </AppLayout>
@@ -68,7 +70,8 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       ? Number(params.year)
       : years[0];
 
-    festival = await fetcher<Festival>(`/info/festivals/${defaultYear}/`);
+    festival = await fetcher<Festival>(`/info/festivals/${defaultYear}/`);   
+
   } catch ({ statusCode }) {
     switch (statusCode) {
     case 404:
@@ -77,12 +80,15 @@ export const getServerSideProps = async ({ params }: GetServerSidePropsContext<R
       throw new InternalServerError();
     }
   }
-
+  const settings = await fetcher<{ show_volunteers: boolean }>('/info/settings/');
+  const showVolunteers = settings.show_volunteers;
+  
   return {
     props: {
       festival,
       years,
       defaultYear,
+      showVolunteers,
     },
   };
 };

--- a/src/services/api/settings-adapter.ts
+++ b/src/services/api/settings-adapter.ts
@@ -35,9 +35,9 @@ const mapDTOToSettings = (dto: SettingsDTO): Settings => ({
     title: project.title,
   })),
   permissions: {
-    team: dto.show_team,
-    volunteers: dto.show_volunteers,
-    sponsors: dto.show_sponsors,
+    show_team: dto.show_team,
+    show_volunteers: dto.show_volunteers,
+    show_sponsors: dto.show_sponsors,
     mission: true,
     'about-us': true,
   }

--- a/src/services/api/settings-adapter.ts
+++ b/src/services/api/settings-adapter.ts
@@ -36,6 +36,7 @@ const mapDTOToSettings = (dto: SettingsDTO): Settings => ({
   })),
   permissions: {
     team: dto.show_team,
+    volunteers: dto.show_volunteers,
     sponsors: dto.show_sponsors,
     mission: true,
     'about-us': true,


### PR DESCRIPTION
## Ссылка на задачу
[Переход по ссылке на список волонтёров падает с 500 ошибкой. #562](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/562)

Когда show_volunteers равно false: Кнопка с ссылкой на страницу команды не отображается, а поле ведет себя как обычное числовое поле.
Когда show_volunteers равно true: Появляется кнопка со ссылкой на страницу команды.    

Получение значения show_volunteers:
В getServerSideProps компонента Team добавлено извлечение значения show_volunteers из API (/info/settings/).
Значение show_volunteers передается в компонент History и далее в компонент HistoryTitle.

Обработка логики в HistoryTitle:
Компонент HistoryTitle принимает свойство showVolunteers.
В объекте cards добавлен buttonProps только если showVolunteers равно true. Если showVolunteers равно false, свойство buttonProps не устанавливается, и кнопка не рендерится.