### PR TITLE
Feature/issue 561/fix cursor for non links

### DIFF
--- a/src/components/history-page/title/history-title-card.tsx
+++ b/src/components/history-page/title/history-title-card.tsx
@@ -22,6 +22,9 @@ export const HistoryTitleCard = ({ item }: {item: ICard}) => {
           type='button'
           size='xxl'
           border='none'
+          className={cn({
+            [style.buttonDefault]: !item.buttonProps, 
+          })}
           {...(item.count && item.buttonProps)}
         >
           {item.count ? item.count.toString() : '0'}

--- a/src/components/history-page/title/history-title.module.css
+++ b/src/components/history-page/title/history-title.module.css
@@ -61,6 +61,10 @@
   display: flex;
 }
 
+.buttonDefault {
+  cursor: default;
+}
+
 .button.link.subtitle {
   overflow: hidden;
   padding: 0;


### PR DESCRIPTION
## Ссылка на задачу
[Некорректный курсор на не ссылках. #561](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/561)

Обновлен стили и компоненты так, чтобы курсор менялся на указатель только на элементах, которые действительно являются ссылками. Для остальных элементов курсор оставаться стандартным. 