### PR TITLE
Feature/issue 557/donation rout active style

### DIFF
--- a/src/components/donation-link/donation-link.module.css
+++ b/src/components/donation-link/donation-link.module.css
@@ -38,6 +38,13 @@
       visibility: visible;
     }
   }
+  
+  &.active { 
+    &::before,
+    &::after {
+      visibility: visible;
+    }
+  }
 }
 
 .icon {

--- a/src/components/donation-link/donation-link.module.css
+++ b/src/components/donation-link/donation-link.module.css
@@ -32,13 +32,7 @@
     border-top-right-radius: 200% 100%;
   }
 
-  &:hover {
-    &::before,
-    &::after {
-      visibility: visible;
-    }
-  }
-  
+  &:hover,
   &.active { 
     &::before,
     &::after {

--- a/src/components/donation-link/donation-link.tsx
+++ b/src/components/donation-link/donation-link.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames/bind';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 import { Icon } from 'components/ui/icon';
 
@@ -11,10 +12,12 @@ const cx = cn.bind(styles);
 
 export const DonationLink = (props: Pick<LinkProps, 'href'>): JSX.Element => {
   const { href } = props;
+  const router = useRouter();
+  const isActive = router.asPath === href;
 
   return (
     <Link href={href}>
-      <a className={cx('link')}>
+      <a className={cx('link', { active: isActive })}>
         <Icon glyph="plus" className={cx('icon')}/>
         <span className={cx('text')}>
           Поддержать


### PR DESCRIPTION
## Ссылка на задачу
[Активация кнопки Поддержать при переходе на неё #557](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/557)

При переходе на страницу "Поддержать", кнопка корректно отображается как активная.

Выполнена стилизация в файле CSS через использование класса .link.active.

В Компоненте реализовано хук useRouter из next/router, чтобы определить текущий маршрут (router.asPath).