### PR TITLE
Bugfix news query

### DIFF
--- a/src/services/api/news-adapter.ts
+++ b/src/services/api/news-adapter.ts
@@ -72,7 +72,7 @@ export const useNews = (filters: NewsFilters) => {
     }
 
     return getNewsCacheKey({
-      month: (filters.month && filters.year) ? filters.month : undefined,
+      month: filters.month,
       year: filters.year,
       limit: NEWS_PER_PAGE,
       offset: pageIndex * NEWS_PER_PAGE,


### PR DESCRIPTION
## Описание
Pull Request исправляет фильтрацию поиска по месяцу и году, теперь они зависимы друг от друга. Это значит, что если не выбран год или месяц в селектах будут отображаться все доступные варианты, но если выбрать конкретный год или месяц, то у второго селекта будут доступны только те варианты которые есть в рамка выбранного первым селектом.

## Ссылка на задачу
[Некорректно работающий фильтр по месяцам #560](https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/560)
