### PR TITLE
Feature/festival event time zone

### DIFF
--- a/src/components/event-card/event-card.module.css
+++ b/src/components/event-card/event-card.module.css
@@ -113,9 +113,9 @@
 
 .timeZone {
   @mixin text;
-  @mixin textMedium;
+  @mixin textSmall;
 
   margin-left: 5px;
-  line-height: 30px;
+  line-height: 1;
   vertical-align: super;
 }

--- a/src/components/festival-event-card/festival-event-card.module.css
+++ b/src/components/festival-event-card/festival-event-card.module.css
@@ -163,6 +163,7 @@
   @mixin textMedium;
 
   margin-left: 5px;
-  line-height: 30px;
+  font-weight: normal;
+  line-height: 1;
   vertical-align: super;
 }

--- a/src/components/performance-event-list/item/performance-event-list-item.module.css
+++ b/src/components/performance-event-list/item/performance-event-list-item.module.css
@@ -21,3 +21,13 @@
     min-width: 240px;
   }
 }
+
+.timeZone {
+  @mixin text;
+  @mixin textLarge;
+
+  margin-left: 5px;
+  font-weight: normal;
+  line-height: 1;
+  vertical-align: super;
+}

--- a/src/components/performance-event-list/item/performance-event-list-item.tsx
+++ b/src/components/performance-event-list/item/performance-event-list-item.tsx
@@ -27,6 +27,9 @@ export const PerformanceEventListItem: FC<PerformanceEventListProps> = (props) =
       {date && (
         <time className={cx('date')}>
           {date}
+          <span className={cx('timeZone')}>
+            мск
+          </span>
         </time>
       )}
       {actionText && actionUrl && (


### PR DESCRIPTION
## Описание
Исправление вертикального выравнивания часового пояса относительно основного текста, добавление часового пояса на страницу /performances/{id}

<img width="630" alt="Снимок экрана 2024-09-22 в 16 38 13" src="https://github.com/user-attachments/assets/4565d55a-6468-419a-939d-3b14456870d4">
<img width="547" alt="Снимок экрана 2024-09-22 в 16 38 04" src="https://github.com/user-attachments/assets/5b424865-069d-4a01-9d1a-2844750a5069">

<img width="487" alt="Снимок экрана 2024-09-22 в 16 53 37" src="https://github.com/user-attachments/assets/967ce903-b6c9-4700-a670-8f7c2335b6f2">

 

## Ссылка на задачу
https://github.com/Studio-Yandex-Practicum/lubimovka_frontend/issues/580#issue-2514330973
