### PR TITLE
Added title prop to actionText in constructor-content

### DIFF
--- a/src/components/constructor-content/constructor-content.tsx
+++ b/src/components/constructor-content/constructor-content.tsx
@@ -294,7 +294,7 @@ export const ConstructorContent: React.FC<ConstructorContentProps> = (props) => 
           <ConstructorLink
             description={content_item.description}
             // TODO: получить текст ссылки в ответе API
-            actionText="Перейти"
+            actionText={content_item.title}
             url={content_item.url}
           />
         </ConstructorContentSection>


### PR DESCRIPTION
## Описание
Настраиваемый текст на кнопке перехода для элемента "Ссылка" в блоке конструктора (блоги/новости/проекты).
Теперь вместо стандартного текста "Перейти" будет отображаться текст из названия ссылки

## Ссылка на задачу
#600 
